### PR TITLE
Fixed the rendering width of text that containing inline icons

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -715,7 +715,7 @@ function EID:renderString(str, position, scale, kcolor)
 		local strFiltered, spriteTable = EID:filterIconMarkup(textPart[1], position.X, position.Y)
 		EID:renderInlineIcons(spriteTable, position.X + offsetX, position.Y)
 		EID.font:DrawStringScaledUTF8(strFiltered, position.X + offsetX, position.Y, scale.X, scale.Y, textPart[2], 0, false)
-		offsetX = offsetX + textPart[3]
+		offsetX = offsetX + EID:getStrWidth(strFiltered)
 	end
 	return textPartsTable[#textPartsTable][2]
 end


### PR DESCRIPTION
This text is not rendered correctly, because `textPart[3]` does not filter out inline icons.
```
Test:{{ArrowUp}}ABC{{ColorGray}}DEF
```
