### PR TITLE
Fixed wrong offset when rendering scaled text

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -718,7 +718,7 @@ function EID:renderString(str, position, scale, kcolor)
 		local strFiltered, spriteTable = EID:filterIconMarkup(textPart[1], position.X, position.Y)
 		EID:renderInlineIcons(spriteTable, position.X + offsetX, position.Y)
 		EID.font:DrawStringScaledUTF8(strFiltered, position.X + offsetX, position.Y, scale.X, scale.Y, textPart[2], 0, false)
-		offsetX = offsetX + EID:getStrWidth(strFiltered)
+		offsetX = offsetX + EID:getStrWidth(strFiltered) * scale.X
 	end
 	return textPartsTable[#textPartsTable][2]
 end


### PR DESCRIPTION
The `scale`  was ignored incorrectly in commit [5be3b82](https://github.com/wofsauge/External-Item-Descriptions/commit/5be3b8260cf47b3a88a3b8532b37b9f9cf3692af).