### PR TITLE
Update Era Walk description (ab+/en_us.lua)

### DIFF
--- a/descriptions/ab+/en_us.lua
+++ b/descriptions/ab+/en_us.lua
@@ -754,7 +754,7 @@ EID.descriptions["en_us"].cards={
 	{"51", "Holy Card", "Grants the Holy Mantle effect for one room#(Next damage you take is 0)#25% Chance to spawn another holy card"},
 	{"52", "Huge Growth", "↑ +7 Damage up#↑ +30 Range up#↑ +Size up#Crush Rocks!#Effect lasts for current room"},
 	{"53", "Ancient Recall", "Spawns 3 random cards when used"},
-	{"54", "Era Walk", "Slow down enemies#↓ -0.5 Speed down#-1 Shot Speed down#Effect lasts for current room"},
+	{"54", "Era Walk", "Slow down enemies#↑ +0.5 Speed up#-1 Shot Speed down#Effect lasts for current room"},
 }
 
 


### PR DESCRIPTION
The Era Walk card was displaying `↓ -0.5 Speed down` instead of `↑ +0.5 Speed up` in `en_us.lua`.

`en_us_detailed.lua` displays the correct description.