### PR TITLE
Fixed typo in Mod Config Menu

### DIFF
--- a/mod_config_menu.lua
+++ b/mod_config_menu.lua
@@ -899,7 +899,7 @@ if MCMLoaded then
 				if EID.Config["ShowQuality"] then
 					onOff = "True"
 				end
-				return "Display Qualtiy Info: " .. onOff
+				return "Display Quality Info: " .. onOff
 			end,
 			OnChange = function(currentBool)
 				EID.Config["ShowQuality"] = currentBool


### PR DESCRIPTION
Replaced `Qualtiy` with `Quality` on the "Visuals" page.