### PR TITLE
Better Spindown Dice method

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -751,10 +751,11 @@ end
 
 -- Converts a given CollectibleID into the respective Spindown dice result
 function EID:getSpindownResult(collectibleID)
+	local config = Isaac.GetItemConfig()
 	local newID = collectibleID
 	repeat
 		newID = newID - 1
-	until( EID.SpindownDiceSkipIDs[newID] == nil)
+	until config:GetCollectible(newID) and not config:GetCollectible(newID).Hidden
 	return newID
 end
 

--- a/eid_data.lua
+++ b/eid_data.lua
@@ -1,25 +1,3 @@
--- Item IDs that are skipped when using the Spindown dice
-EID.SpindownDiceSkipIDs = {
-	[43]=true,
-	[59]=true,
-	[61]=true,
-	[235]=true,
-	[587]=true,
-	[613]=true,
-	[620]=true,
-	[630]=true,
-	[648]=true,
-	[656]=true,
-	[662]=true,
-	[666]=true,
-	[710]=true,
-	[711]=true,
-	[713]=true,
-	[714]=true,
-	[715]=true,
-	[718]=true
-}
-
 EID.ButtonToIconMap = {
 	[ButtonAction.ACTION_SHOOTUP] = "{{ButtonY}}",
 	[ButtonAction.ACTION_SHOOTDOWN] = "{{ButtonA}}",


### PR DESCRIPTION
Instead of a set table of IDs to skip, it now uses the vanilla rules of skipping items (if it exists and is not tagged as "hidden" in itemconfig). This should make it properly work with modded items and also be futureproof.