### PR TITLE
Bag of Crafting locked items check

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -759,10 +759,26 @@ function EID:getSpindownResult(collectibleID)
 	return newID
 end
 
+function EID:GetMaxCollectibleID()
+    local id = CollectibleType.NUM_COLLECTIBLES-1
+    local step = 16
+    while step > 0 do
+        if Isaac.GetItemConfig():GetCollectible(id+step) ~= nil then
+            id = id + step
+        else
+            step = step // 2
+        end
+    end
+    
+    return id
+end
+
+local maxCollectibleID = nil
 function EID:isCollectibleUnlocked(collectibleID, itemPoolOfItem)
 	local itemPool = Game():GetItemPool()
 	local itemConfig = Isaac.GetItemConfig()
-	for i= 1, GetMaxCollectibleID() do
+	if (not maxCollectibleID) then maxCollectibleID = EID:GetMaxCollectibleID() end
+	for i= 1, maxCollectibleID do
 		if ItemConfig.Config.IsValidCollectible(i) and i ~= collectibleID then
 			itemPool:AddRoomBlacklist(i)
 		end
@@ -822,20 +838,20 @@ end
 -- Converts a given table into a string containing the crafting icons of the table, which are also grouped to reduce render lag
 -- Example input: {1,1,1,2,2,3,3,3}
 -- Result: "3{{Crafting3}}2{{Crafting2}}3{{Crafting1}}"
+local emptyPickupTable = {}
+for i=1,25 do emptyPickupTable[i] = 0 end
 function EID:tableToCraftingIconsMerged(craftTable)
 	local sortedList = {table.unpack(craftTable)}
 	table.sort(sortedList, function(a, b) return a > b end)
-	local filteredList = {}
+	local filteredList = {table.unpack(emptyPickupTable)}
 	for _,nr in ipairs(sortedList) do
-		if filteredList[nr] == nil then
-			filteredList[nr] = 1
-		else
-			filteredList[nr] = filteredList[nr] +1
-		end
+		filteredList[nr] = filteredList[nr] +1
 	end
 	local iconString = ""
-	for nr,count in pairs(filteredList) do
-		iconString = iconString..count.."{{Crafting"..nr.."}}"
+	for nr,count in ipairs(filteredList) do
+		if (count > 0) then
+			iconString = iconString..count.."{{Crafting"..nr.."}}"
+		end
 	end
 	return iconString
 end

--- a/eid_config.lua
+++ b/eid_config.lua
@@ -176,8 +176,8 @@ EID.UserConfig = {
 	["BagOfCraftingCombinationMax"] = 12,
 	-- Changes the number of random recipes calculated
 	-- Higher numbers will cause lag spikes on new pickup sets!
-	-- Default = 500
-	["BagOfCraftingRandomResults"] = 500,
+	-- Default = 400
+	["BagOfCraftingRandomResults"] = 400,
 	-- Set the keybinding to toggle the scroll feature of the bag of crafting descriptions
 	-- look into the AB+ or Repentance documentation for the key names here: https://wofsauge.github.io/IsaacDocs/rep/enums/ButtonAction.html
 	-- Default = ButtonAction.ACTION_MAP
@@ -185,6 +185,9 @@ EID.UserConfig = {
 	-- Display craftable item names, moving the recipe to a new line
 	-- Default = false
 	["BagOfCraftingDisplayNames"] = false,
+	-- Display locked item recipes, which will all turn into Breakfast
+	-- Default = false
+	["BagOfCraftingDisplayBreakfast"] = false,
 	
 	---------Mouse Controls-----------
 	
@@ -282,9 +285,10 @@ EID.DefaultConfig = {
 	["DisplayBagOfCrafting"] = "always",
 	["BagOfCraftingResults"] = 7,
 	["BagOfCraftingCombinationMax"] = 12,
-	["BagOfCraftingRandomResults"] = 500,
+	["BagOfCraftingRandomResults"] = 400,
 	["BagOfCraftingToggleKey"] = ButtonAction.ACTION_MAP,
 	["BagOfCraftingDisplayNames"] = false,
+	["BagOfCraftingDisplayBreakfast"] = false,
 	["SpindownDiceResults"] = 3,
 	["EnableMouseControls"] = false,
 	["ShowCursor"] = false,

--- a/mod_config_menu.lua
+++ b/mod_config_menu.lua
@@ -1032,6 +1032,28 @@ if MCMLoaded then
 			Info = {"If on, each result takes two lines; lower your displayed results accordingly"}
 		}
 	)
+	-- Bag of Crafting Breakfast recipes
+	MCM.AddSetting(
+		"EID",
+		"Crafting",
+		{
+			Type = ModConfigMenu.OptionType.BOOLEAN,
+			CurrentSetting = function()
+				return EID.Config["BagOfCraftingDisplayBreakfast"]
+			end,
+			Display = function()
+				local onOff = "False"
+				if EID.Config["BagOfCraftingDisplayBreakfast"] then
+					onOff = "True"
+				end
+				return "Show Locked Recipes: " .. onOff
+			end,
+			OnChange = function(currentBool)
+				EID.Config["BagOfCraftingDisplayBreakfast"] = currentBool
+			end,
+			Info = {"Recipes for locked items turn into Breakfast, filling the list with essentially useless recipes"}
+		}
+	)
 	
 	MCM.AddSpace("EID", "Crafting")
 	--------Clear Floor---------


### PR DESCRIPTION
Adds kittenchilly's collectible unlock status check for Spindown Dice to the Bag of Crafting

* Move GetMaxCollectibleID() from being a local Bag of Crafting function to an EID: api function
* Add an option to hide locked recipes (when shown, they'll have a Breakfast icon appended to them)
* Add quality color to the equals sign when not displaying item names
* Change the crafting icon display function to use ipairs instead of pairs, so the order of ingredients is consistent
* Lower the default random recipe setting slightly