### PR TITLE
Revert transformation names

### DIFF
--- a/descriptions/ab+/en_us.lua
+++ b/descriptions/ab+/en_us.lua
@@ -844,20 +844,20 @@ EID.descriptions["en_us"].dice={
 
 ---------- Transformations ----------
 EID.descriptions["en_us"].transformations = {
-	"",					-- 0 = none
+	"",				-- 0 = none
 	"Guppy",			-- 1
 	"Fun Guy",			-- 2
-	"Beelzebub",		-- 3
-	"Conjoined",		-- 4
+	"Lord of the Flies",		-- 3
+	"Conjoined",			-- 4
 	"Spun",				-- 5
-	"Yes Mother?",		-- 6
+	"Mom",				-- 6
 	"Oh Crap",			-- 7
 	"Bob",				-- 8
-	"Leviathan",		-- 9
+	"Leviathan",			-- 9
 	"Seraphim",			-- 10
-	"Super Bum",		-- 11
+	"Super Bum",			-- 11
 	"Bookworm",			-- 12
-	"Spider Baby",		-- 13
+	"Spider Baby",			-- 13
 	"Adult",			-- 14
 	"Stompy"			-- 15
 }


### PR DESCRIPTION
I changed the names for Lord of the Flies to Beelzebub and Mom to Yes Mother?, which broke the transformation icons. Unless there's an easier fix for this, I'm reverting the change as not only it should be fixed, it should be implemented across all localization files (where there's no localized names for those transformations).