### PR TITLE
remove the low max item count warning message

### DIFF
--- a/descriptions/rep/en_us.lua
+++ b/descriptions/rep/en_us.lua
@@ -34,6 +34,7 @@ local repCollectibles={
 	[52] = {"52", "Dr. Fetus", "Bomb tears#Each bomb deals 10x your damage#If that results in over 60 damage, it instead deals 5x your damage + 30#↓ -60% Tears down"}, --Dr. Fetus
 	[53] = {"53", "Magneto", "Magnetic attraction for pickups#Opens chests remotely, ignoring damage of spike chests"}, -- Magneto
 	[55] = {"55", "Mom's Eye", "Chance to shoot a tear backwards"}, -- Mom's Eye
+	[59] = {"59", "The Book of Belial", "<Item not obtainable>"}, -- The Book of Belial (Judas's Birthright Version)
 	[62] = {"62", "Charm of the Vampire", "↑ +0.3 Damage up#Heals half a heart for every 13 enemies killed"}, -- Charm of the Vampire
 	[64] = {"64", "Steam Sale", "-50% on shop items price#Getting this item multiple times reduces the price further"}, -- Steam Sale
 	[67] = {"67", "Sister Maggy", "Normal tear familiar#Deals 6 damage per tear"}, -- Sister Maggy

--- a/eid_api.lua
+++ b/eid_api.lua
@@ -436,6 +436,7 @@ function EID:getObjectName(Type, Variant, SubType)
 		end
 	end
 	if tableName == "collectibles" then
+		if EID.itemConfig:GetCollectible(SubType) == nil then return Type.."."..Variant.."."..SubType end
 		local vanillaName = EID.itemConfig:GetCollectible(SubType).Name
 		return name or (not string.find(vanillaName, "^#") and vanillaName) or EID.descriptions["en_us"][tableName][SubType][2] or vanillaName
 	elseif tableName == "trinkets" then
@@ -764,8 +765,7 @@ function EID:getSpindownResult(collectibleID)
 end
 
 function EID:GetMaxCollectibleID()
-	--start a little lower than NUM_COLLECTIBLES, due to mods with outdated items.xmls that are missing newer items
-	local id = CollectibleType.NUM_COLLECTIBLES-17
+	local id = CollectibleType.NUM_COLLECTIBLES-1
 	local step = 16
 	while step > 0 do
 		if EID.itemConfig:GetCollectible(id+step) ~= nil then
@@ -803,6 +803,7 @@ function EID:isCollectibleUnlockedAnyPool(collectibleID)
 	--THIS FUNCTION IS FOR REPENTANCE ONLY due to using Repentance XML data; currently used by the Achievement Check, Spindown Dice, and Bag of Crafting
 	if not REPENTANCE then return true end
 	local item = EID.itemConfig:GetCollectible(collectibleID)
+	if item == nil then return false end
 	if EID.itemUnlockStates[collectibleID] == nil then
 		--whitelist all quest items and items with no associated achievement
 		if item.AchievementID == -1 or (item.Tags and item.Tags & ItemConfig.TAG_QUEST == ItemConfig.TAG_QUEST) then

--- a/eid_bagofcrafting.lua
+++ b/eid_bagofcrafting.lua
@@ -184,16 +184,13 @@ for i = 1, EID.XMLMaxItemID do
 	end
 end
 
---don't sort if there's a collectible ID discrepancy
-if EID:GetMaxCollectibleID() == EID.XMLMaxItemID then
-	table.sort(sortedIDs, function(a, b)
-		if EID.XMLItemQualities[a] == EID.XMLItemQualities[b] then
-			return (EID:getObjectName(5, 100, a) < EID:getObjectName(5, 100, b))
-		else
-			return (EID.XMLItemQualities[a] > EID.XMLItemQualities[b])
-		end
-	end)
-end
+table.sort(sortedIDs, function(a, b)
+	if EID.XMLItemQualities[a] == EID.XMLItemQualities[b] then
+		return (EID:getObjectName(5, 100, a) < EID:getObjectName(5, 100, b))
+	else
+		return (EID.XMLItemQualities[a] > EID.XMLItemQualities[b])
+	end
+end)
 
 local customRNGSeed = 0x77777770
 local customRNGShift = {0,0,0}
@@ -601,6 +598,9 @@ local function detectModdedItems()
 		maxItemID = EID:GetMaxCollectibleID()
 	end
 	if maxItemID > EID.XMLMaxItemID then
+		return true
+	end
+	if EID.itemConfig:GetCollectible(EID.XMLMaxItemID) == nil then
 		return true
 	end
 	return false

--- a/main.lua
+++ b/main.lua
@@ -551,27 +551,19 @@ EID:AddCallback(ModCallbacks.MC_POST_UPDATE, EID.onGameUpdate)
 local hasShownAchievementWarning = false
 
 local function renderAchievementInfo()
-	if REPENTANCE and not EID.Config.DisableAchievementCheck and game:GetFrameCount() < 10*30 then
-		if EID:GetMaxCollectibleID() < EID.XMLMaxItemID then
-			local demoDescObj = EID:getDescriptionObj(-999, -1, 1)
-			demoDescObj.Name = EID:getDescriptionEntry("AchievementWarningTitle") or ""
-			demoDescObj.Description = EID:getDescriptionEntry("OutdatedModWarningText") or ""
-			EID:displayPermanentText(demoDescObj)
-			hasShownAchievementWarning = true
-		else
-			local characterID = Game():GetPlayer(0):GetPlayerType()
-			--ID 21 = Tainted Isaac. Tainted characters have definitely beaten Mom! (Fixes Tainted Lost's item pools ruining this check)
-			if characterID < 21 and game.Challenge == 0 then
-				local hasBookOfRevelationsUnlocked = EID:isCollectibleUnlockedAnyPool(CollectibleType.COLLECTIBLE_BOOK_OF_REVELATIONS or CollectibleType.COLLECTIBLE_BOOK_REVELATIONS)
-				if not hasBookOfRevelationsUnlocked then
-					local hasCubeOfMeatUnlocked = EID:isCollectibleUnlockedAnyPool(CollectibleType.COLLECTIBLE_CUBE_OF_MEAT)
-					if not hasCubeOfMeatUnlocked then
-						local demoDescObj = EID:getDescriptionObj(-999, -1, 1)
-						demoDescObj.Name = EID:getDescriptionEntry("AchievementWarningTitle") or ""
-						demoDescObj.Description = EID:getDescriptionEntry("AchievementWarningText") or ""
-						EID:displayPermanentText(demoDescObj)
-						hasShownAchievementWarning = true
-					end
+	if REPENTANCE and not EID.Config.DisableAchievementCheck and game:GetFrameCount() < 10*30 and game.Challenge == 0 then
+		local characterID = Game():GetPlayer(0):GetPlayerType()
+		--ID 21 = Tainted Isaac. Tainted characters have definitely beaten Mom! (Fixes Tainted Lost's item pools ruining this check)
+		if characterID < 21 then
+			local hasBookOfRevelationsUnlocked = EID:isCollectibleUnlockedAnyPool(CollectibleType.COLLECTIBLE_BOOK_OF_REVELATIONS or CollectibleType.COLLECTIBLE_BOOK_REVELATIONS)
+			if not hasBookOfRevelationsUnlocked then
+				local hasCubeOfMeatUnlocked = EID:isCollectibleUnlockedAnyPool(CollectibleType.COLLECTIBLE_CUBE_OF_MEAT)
+				if not hasCubeOfMeatUnlocked then
+					local demoDescObj = EID:getDescriptionObj(-999, -1, 1)
+					demoDescObj.Name = EID:getDescriptionEntry("AchievementWarningTitle") or ""
+					demoDescObj.Description = EID:getDescriptionEntry("AchievementWarningText") or ""
+					EID:displayPermanentText(demoDescObj)
+					hasShownAchievementWarning = true
 				end
 			end
 		end


### PR DESCRIPTION
I'm not sure if there's false positives with the check, but the reception has been negative, and the warning doesn't really help people figure out how to fix it (if they even want to fix it)
I think there's a massive epidemic of people with broken mods from items/sounds.xml overwrites right now, and well, I sure hope they don't try to beat Mother, but I guess it's better to just stay out of it
I added a couple extra collectible = nil checks to the functions that were tending to cause issues