### PR TITLE
Improve recipe caching

### DIFF
--- a/eid_config.lua
+++ b/eid_config.lua
@@ -54,8 +54,8 @@ EID.UserConfig = {
 	-- Default = Keyboard.KEY_F2
 	["HideKey"] = Keyboard.KEY_F2,
 	-- Set the controller binding to toggle the descriptions
-	-- Use the Controller enum at the top of this file, or a number
-	-- Of note are Controller.STICK_LEFT and Controller.STICK_RIGHT, which aren't used in-game with default controls
+	-- Use the Controller names here: https://github.com/wofsauge/External-Item-Descriptions/blob/master/mod_config_menu.lua#L1 or a number
+	-- Of note are Controller.STICK_LEFT and Controller.STICK_RIGHT (pushing the sticks in), which aren't used in-game with default controls
 	-- Default = none (-1)
 	["HideButton"] = -1,
 	-- Initial displaystate. Can be used to change the toggle behavior of the "Hide Key" event
@@ -237,8 +237,8 @@ EID.UserConfig = {
 	-- Default = Keyboard.KEY_F3
 	["CraftingResultKey"] = Keyboard.KEY_F4,
 	-- Set the controller binding to toggle viewing the description of the item ready to be crafted in the bag
-	-- Use the Controller enum at the top of this file, or a number
-	-- Of note are Controller.STICK_LEFT and Controller.STICK_RIGHT, which aren't used in-game with default controls
+	-- Use the Controller names here: https://github.com/wofsauge/External-Item-Descriptions/blob/master/mod_config_menu.lua#L1 or a number
+	-- Of note are Controller.STICK_LEFT and Controller.STICK_RIGHT (pushing the sticks in), which aren't used in-game with default controls
 	-- Default = none (-1)
 	["CraftingResultButton"] = -1,
 	

--- a/main.lua
+++ b/main.lua
@@ -8,7 +8,7 @@ local game = Game()
 
 require("eid_config")
 EID.Config = EID.UserConfig
-EID.Config.Version = "3.2"
+EID.Config.Version = "3.2" -- note: changing this will reset everyone's settings to default!
 EID.ModVersion = "4.1"
 EID.DefaultConfig.Version = EID.Config.Version
 EID.isHidden = false


### PR DESCRIPTION
I did testing of how many milliseconds each part of the crafting algorithm takes, and was surprised (but glad) to find that the actual recipe result calculation is by far the slowest part, rather than the combination / random pull steps

I noticed that stupidly I wasn't caching recipe results unless they were on a locked item, and adding that caching indeed greatly reduces recipe crunching time as it builds a database (in testing, it may start at 130ms, and go down to 20ms after a few refreshes)
I tested switching to local XML tables in the file, but didn't see any speed increase, which I'm glad for cause I quite like having the pool and quality info outside of the code file

I also added a little warning on the config version

Hopefully I'm done for a bit :)