### PR TITLE
Support items inside Crane Game

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -491,7 +491,10 @@ function EID:hasDescription(entity)
 		isAllowed = isAllowed or (entity.Variant == PickupVariant.PICKUP_PILL and EID.Config["DisplayPillInfo"])
 		return isAllowed and entity.SubType > 0
 	end
-	isAllowed = isAllowed or (entity.Type == 1000 and entity.Variant == EffectVariant.DICE_FLOOR and EID.Config["DisplayDiceInfo"]) or (entity.Type == 6 and entity.Variant == 16 and (not entity:GetSprite():IsPlaying("Broken") and not entity:GetSprite():IsPlaying("Prize")))
+	if entity.Type == 6 and entity.Variant == 16 and EID.Config["DisplayCraneInfo"] and REPENTANCE then
+		isAllowed = not entity:GetSprite():IsPlaying("Broken") and not entity:GetSprite():IsPlaying("Prize")
+	end
+	isAllowed = isAllowed or (entity.Type == 1000 and entity.Variant == EffectVariant.DICE_FLOOR and EID.Config["DisplayDiceInfo"])
 	return isAllowed
 end
 

--- a/eid_api.lua
+++ b/eid_api.lua
@@ -491,7 +491,7 @@ function EID:hasDescription(entity)
 		isAllowed = isAllowed or (entity.Variant == PickupVariant.PICKUP_PILL and EID.Config["DisplayPillInfo"])
 		return isAllowed and entity.SubType > 0
 	end
-	isAllowed = isAllowed or (entity.Type == 1000 and entity.Variant == EffectVariant.DICE_FLOOR and EID.Config["DisplayDiceInfo"]) or (entity.Type == 6 and entity.Variant == 16)
+	isAllowed = isAllowed or (entity.Type == 1000 and entity.Variant == EffectVariant.DICE_FLOOR and EID.Config["DisplayDiceInfo"]) or (entity.Type == 6 and entity.Variant == 16 and (not entity:GetSprite():IsPlaying("Broken") and not entity:GetSprite():IsPlaying("Prize")))
 	return isAllowed
 end
 

--- a/eid_api.lua
+++ b/eid_api.lua
@@ -491,7 +491,7 @@ function EID:hasDescription(entity)
 		isAllowed = isAllowed or (entity.Variant == PickupVariant.PICKUP_PILL and EID.Config["DisplayPillInfo"])
 		return isAllowed and entity.SubType > 0
 	end
-	isAllowed = isAllowed or (entity.Type == 1000 and entity.Variant == EffectVariant.DICE_FLOOR and EID.Config["DisplayDiceInfo"])
+	isAllowed = isAllowed or (entity.Type == 1000 and entity.Variant == EffectVariant.DICE_FLOOR and EID.Config["DisplayDiceInfo"]) or (entity.Type == 6 and entity.Variant == 16)
 	return isAllowed
 end
 

--- a/eid_config.lua
+++ b/eid_config.lua
@@ -195,6 +195,13 @@ EID.UserConfig = {
 	-- Default = true
 	["DisplayDiceInfo"] = true,
 	
+	--------Crane Game---------
+	-- REPENTANCE ONLY!!!
+	
+	-- Toggle Display for items inside of a Crane Game
+	-- Default = true
+	["DisplayCraneInfo"] = true,
+	
 	---------Bag of Crafting-----------
 	-- REPENTANCE ONLY!!!
 	
@@ -355,6 +362,7 @@ EID.DefaultConfig = {
 	["DisplaySacrificeInfo"] = true,
 	["DisplayDiceInfo"] = true,
 	["DisplayBagOfCrafting"] = "always",
+	["DisplayCraneInfo"] = true,
 	["BagOfCraftingResults"] = 7,
 	["BagOfCraftingCombinationMax"] = 12,
 	["BagOfCraftingRandomResults"] = 400,

--- a/main.lua
+++ b/main.lua
@@ -788,6 +788,7 @@ local function onRender(t)
 			local descriptionObj = EID:getDescriptionObj(5, 100, EID:getEntityData(closest, "EID_CraneItemType"))
 			
 			EID:printDescription(descriptionObj)
+			return
 		end
 	end
 	

--- a/main.lua
+++ b/main.lua
@@ -214,6 +214,21 @@ function EID:IsAltChoice(pickup)
 end
 
 ---------------------------------------------------------------------------
+-------------------------Handle Crane Game-----------------------------
+
+function EID:postGetCollectible(selectedCollectible, itemPoolType, decrease, seed)
+	if itemPoolType == ItemPoolType.POOL_CRANE_GAME then
+		local cranes = Isaac.FindByType(6, 16)
+		for _, crane in pairs(cranes) do
+			if not EID:getEntityData(crane, "EID_CraneItemType") then
+				crane:GetData()["EID_CraneItemType"] = selectedCollectible
+			end
+		end
+	end
+end
+EID:AddCallback(ModCallbacks.MC_POST_GET_COLLECTIBLE, EID.postGetCollectible)
+
+---------------------------------------------------------------------------
 ---------------------------Printing Functions------------------------------
 
 function EID:printDescription(desc)
@@ -755,10 +770,25 @@ local function onRender(t)
 		EID:printDescription(origDesc)
 		return
 	end
-
+	
 	if closest.Type == 1000 and closest.Variant == 76 then
 		EID:printDescription(EID:getDescriptionObj(closest.Type, closest.Variant, closest.SubType+1))
 		return
+	end
+	
+	if closest.Type == 6 and closest.Variant == 16 then
+		--Handle Crane Game
+		if EID:getEntityData(closest, "EID_CraneItemType") then
+			if EID:getEntityData(closest, "EID_DontHide") ~= true then
+				if (EID:hasCurseBlind() and EID.Config["DisableOnCurse"]) or (game.Challenge == Challenge.CHALLENGE_APRILS_FOOL and EID.Config["DisableOnAprilFoolsChallenge"]) then
+					EID:renderQuestionMark()
+					return
+				end
+			end
+			local descriptionObj = EID:getDescriptionObj(5, 100, EID:getEntityData(closest, "EID_CraneItemType"))
+			
+			EID:printDescription(descriptionObj)
+		end
 	end
 	
 	if closest.Variant == PickupVariant.PICKUP_TRINKET then

--- a/main.lua
+++ b/main.lua
@@ -138,6 +138,7 @@ function EID:onNewFloor()
 	if REPENTANCE then
 		EID.bagOfCraftingRoomQueries = {}
 		EID.bagOfCraftingFloorQuery = {}
+		EID.CraneItemType = {}
 	end
 end
 EID:AddCallback(ModCallbacks.MC_POST_NEW_LEVEL, EID.onNewFloor)

--- a/mod_config_menu.lua
+++ b/mod_config_menu.lua
@@ -619,9 +619,33 @@ if MCMLoaded then
 		}
 	)
 	
+
+	
 	local diceSteps = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 	if REPENTANCE then
 	
+		--------Crane Game---------
+		MCM.AddSetting(
+			"EID",
+			"Display",
+			{
+				Type = ModConfigMenu.OptionType.BOOLEAN,
+				CurrentSetting = function()
+					return EID.Config["DisplayCraneInfo"]
+				end,
+				Display = function()
+					local onOff = "False"
+					if EID.Config["DisplayCraneInfo"] then
+						onOff = "True"
+					end
+					return "Crane Game Infos: " .. onOff
+				end,
+				OnChange = function(currentBool)
+					EID.Config["DisplayCraneInfo"] = currentBool
+				end
+			}
+		)
+		
 		MCM.AddSpace("EID", "Display")
 	
 		-- Spindown Dice results


### PR DESCRIPTION
Gets what item the crane game should have using POST_GET_COLLECTIBLE. Saves data of the item's type to the crane game and updates depending on what happens to the machine. Displays the item description of the item type in the data.
Basically just makes items inside the crane game have their descriptions show up. Maybe there'll be a better method once we get actual slot support in the API.

Also includes a new config option to enable or disable this.