### PR TITLE
Fixed an error with glitched items descriptions

### DIFF
--- a/descriptions/rep/spa.lua
+++ b/descriptions/rep/spa.lua
@@ -932,11 +932,11 @@ EID.descriptions[languageCode].horsepills={
 }
 
 ---------- Glitched Items Descriptions ----------
+EID.descriptions[languageCode].GlitchedItemText = {
 	-- This will be appended to words to pluralize them, make it "" to not pluralize
 	pluralize = "s",
-
-EID.descriptions[languageCode].GlitchedItemText = {
-		-- Item Config info
+		
+	-- Item Config info
 	AddBlackHearts = "{1} Corazón/zones negro/s",
 	AddBombs = "{1} Bomba/s",
 	AddCoins = "{1} Moneda/s",


### PR DESCRIPTION
When I was copying things I left out the pluralizer, and I copied it, which I just noticed