### PR TITLE
More Flip improvements

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -508,7 +508,9 @@ function EID:hasDescription(entity)
 		isAllowed = isAllowed or (entity.Variant == PickupVariant.PICKUP_TRINKET and EID.Config["DisplayTrinketInfo"])
 		isAllowed = isAllowed or (entity.Variant == PickupVariant.PICKUP_TAROTCARD and EID.Config["DisplayCardInfo"])
 		isAllowed = isAllowed or (entity.Variant == PickupVariant.PICKUP_PILL and EID.Config["DisplayPillInfo"])
-		return isAllowed and (entity.SubType > 0 or EID:getEntityData(entity, "EID_FlipItemID"))
+		return isAllowed and (entity.SubType > 0 or
+			-- For Flip descriptions, allow 5.100.0 pedestals to have descriptions under VERY specific criteria!
+			(REPENTANCE and EID:getEntityData(entity, "EID_FlipItemID") and EID:PlayersHaveCollectible(CollectibleType.COLLECTIBLE_FLIP)))
 	end
 	if entity.Type == 6 and entity.Variant == 16 and EID.Config["DisplayCraneInfo"] and REPENTANCE then
 		isAllowed = not entity:GetSprite():IsPlaying("Broken") and not entity:GetSprite():IsPlaying("Prize") and EID.CraneItemType[tostring(entity.InitSeed)]

--- a/eid_tmtrainer.lua
+++ b/eid_tmtrainer.lua
@@ -28,7 +28,7 @@ local function entityToName(e, plural)
 	local name = localizedNames[e] or EID.XMLEntityNames[e] or localizedNames[eWithZero] or EID.XMLEntityNames[eWithZero] or e
 	
 	--print out entities with no name yet
-	if name == e then print("No name found for " .. e .. " (could be modded)")
+	if name == e then Isaac.DebugString("No name found for " .. e .. " (could be modded)")
 	elseif plural then name = name .. localizedNames["pluralize"] end
 	
 	return name

--- a/main.lua
+++ b/main.lua
@@ -247,7 +247,7 @@ if REPENTANCE then
 	
 	local lastGetItemResult = {nil, nil, nil, nil} -- itemID, Frame, gridIndex, InitSeed
 	
-	function EID:postGetCollectible(selectedCollectible, itemPoolType, decrease, _)
+	function EID:postGetCollectible(selectedCollectible, itemPoolType, decrease, seed)
 		-- Handle Crane Game
 		if itemPoolType == ItemPoolType.POOL_CRANE_GAME then
 			for _, crane in ipairs(Isaac.FindByType(6, 16, -1, true, false)) do
@@ -283,7 +283,7 @@ if REPENTANCE then
 	EID:AddCallback(ModCallbacks.MC_POST_GET_COLLECTIBLE, EID.postGetCollectible)
 
 	-- Handle Flip Item spawn
-	function EID:preRoomEntitySpawn(entityType, variant, subtype, gridIndex, _)
+	function EID:preRoomEntitySpawn(entityType, variant, subtype, gridIndex, seed)
 		flipItemNext = false
 		if entityType == 5 and (variant == 100 or variant == 150) then
 			lastGetItemResult = {nil, Isaac.GetFrameCount(), gridIndex, nil}
@@ -338,7 +338,7 @@ if REPENTANCE then
 			end
 		end
 	end
-	EID:AddCallback(ModCallbacks.MC_PRE_USE_ITEM, EID.CheckFlipGridIndexes)
+	EID:AddCallback(ModCallbacks.MC_PRE_USE_ITEM, EID.CheckFlipGridIndexes, CollectibleType.COLLECTIBLE_FLIP)
 end
 
 ---------------------------------------------------------------------------

--- a/main.lua
+++ b/main.lua
@@ -244,7 +244,6 @@ local initialItemNext = false
 local flipItemNext = false
 if REPENTANCE then
 	EID.flipItemPositions = {}
-	EID.flipItemSeeds = {}
 	
 	local lastGetItemResult = {nil, nil, nil, nil} -- itemID, Frame, gridIndex, InitSeed
 	


### PR DESCRIPTION
Used a combination of InitSeed and GridIndex to be able to keep track of our flippable pedestals much better, hopefully without any performance decrease. (It double-checks every pedestal's grid index each time a collectible is spawned, but I don't see any lag spike even with 100 collectibles in a room)

As far as my testing goes, it now works with Damocles, works with Mr. ME!, works with restocking shops, works with D6, works with Tainted Isaac / Glitched Crown, works with dropping Flip in a room or dropping and exiting and re-entering rooms

The only bug I'm aware of is that re-entering a room that used to have a pedestal, so nothing is spawned there now, and spawning a pedestal in its gridindex will make it will think it's flippable. (Doesn't seem worth the milliseconds to fully delete the data of used-up flip pedestals, so "pedestal at this gridindex is flippable" lingers around)

I'll try and make sure its performance is even better, I have a couple ideas to reduce how much is checked (especially when you don't even have flip), but I think it's safe at the moment