### PR TITLE
Corrupted Data support, fix Diplopia + Flip

### DIFF
--- a/descriptions/rep/en_us.lua
+++ b/descriptions/rep/en_us.lua
@@ -971,22 +971,22 @@ EID.descriptions[languageCode].GlitchedItemText = {
 	[0] = "Damage", "Fire Rate", "Shot Speed", "Range", "Speed", "Tear Effects", "Tear Color", "Flight", "Attack Type", "Familiars", "Luck", "Size", "Color", "Chest Contents", [16] = "All Stats",
 	
 	-- Attribute triggers
-	chain = "{{ColorCyan}}Then:{{CR}} ",
-	active = "{{ColorCyan}}On use:#",
-	pickup_collected = "{{ColorCyan}}When you collect a pickup:#", --chance to?
-	enemy_kill = "{{ColorCyan}}On kill, chance to:#",
-	damage_taken = "{{ColorCyan}}When you take damage:#", --chance to?
-	entity_spawned = "When a {{ColorCyan}}{T1}{{CR}} is spawned:#",
-	tear_fire = "{{ColorCyan}}When you fire a tear, chance to:#",
-	enemy_hit = "{{ColorCyan}}On hitting an enemy, chance to:#",
-	room_clear = "{{ColorCyan}}On room clear:#", --chance to?
+	chain = "Then:{{CR}} ",
+	active = "On use:#",
+	pickup_collected = "When you collect a pickup:#", --chance to?
+	enemy_kill = "On kill, chance to:#",
+	damage_taken = "When you take damage:#", --chance to?
+	entity_spawned = "When a {T1} is spawned:#",
+	tear_fire = "When you fire a tear, chance to:#",
+	enemy_hit = "On hitting an enemy, chance to:#",
+	room_clear = "On room clear:#", --chance to?
 	
 	-- Attribute effects
 	area_damage = "Deal {1} damage in an area around you", 
 	add_temporary_effect = "Gain {1} for the room",
-	convert_entities = "Convert all {{ColorGray}}{1}{{CR}} in the room to {{ColorGray}}{2}{{CR}}",
+	convert_entities = "Convert all {1} in the room to {2}",
 	use_active_item = "Use {1}",
-	spawn_entity = "Spawn a {{ColorGray}}{1}{{CR}}",
+	spawn_entity = "Spawn a {1}",
 	fart = "Fart with size {1}",
 	
 	-- Generic entity names not obtained from entities2.xml

--- a/main.lua
+++ b/main.lua
@@ -323,10 +323,15 @@ if REPENTANCE then
 	EID:AddCallback(ModCallbacks.MC_POST_PICKUP_INIT, EID.postPickupInit, PickupVariant.PICKUP_COLLECTIBLE)
 	
 	function EID:CheckPedestalIndex(entity)
-		-- Only pedestals with indexes that were present at room load can be flip pedestals; fixes shop restock machines
-		if EID.flipItemPositions[curRoomIndex] and EID.flipItemPositions[curRoomIndex][entity.InitSeed] and entity.Index > EID.flipMaxIndex then
-			EID.flipItemPositions[curRoomIndex][entity.InitSeed] = nil
-			entity:GetData()["EID_FlipItemID"] = nil
+		-- Only pedestals with indexes that were present at room load can be flip pedestals
+		-- Fixes shop restock machines and Diplopia... mostly. At least while you're in the room.
+		if entity:GetData()["EID_FlipItemID"] and entity.Index > EID.flipMaxIndex then
+			local curRoomIndex = game:GetLevel():GetCurrentRoomIndex()
+			local gridPos = game:GetRoom():GetGridIndex(entity.Position)
+			local flipEntry = EID.flipItemPositions[curRoomIndex] and EID.flipItemPositions[curRoomIndex][entity.InitSeed]
+			-- only wipe the data if the grid index matches (so Diplopia pedestals don't)
+			if flipEntry and gridPos == flipEntry[2] then EID.flipItemPositions[curRoomIndex][entity.InitSeed] = nil end
+			entity:GetData()["EID_FlipItemID"] = nil 
 		end
 	end
 	EID:AddCallback(ModCallbacks.MC_POST_PICKUP_UPDATE, EID.CheckPedestalIndex, PickupVariant.PICKUP_COLLECTIBLE)


### PR DESCRIPTION
* Prevent Diplopia pedestals from showing Flip descriptions (...until you re-enter the room, but fixing that would get too complicated)
* Glitched item descriptions now check the log only when a new glitched item has spawned rather than when you have TMTRAINER (less log checks + works with Corrupted Data glitched items)
* Moved glitched item color data to the tmtrainer lua file (localizations would get desynced and be harder to make)
* Made effect triggers have more fitting colors than cyan to help tell them apart even more
* Up/Down arrows for the Heart/Pickup stats