### PR TITLE
Use Ultra Greed Door as pathfinder entity

### DIFF
--- a/content/entities2.xml
+++ b/content/entities2.xml
@@ -1,5 +1,0 @@
-<entities anm2root="gfx/" version="5">
-	<entity anm2path="eid_blank.anm2" baseHP="0" boss="0" champion="0" friction="1" id="17" name="EID_PATHCHECKER" shadowSize="0" stageHP="0" gridCollision="none" variant="3169" shutdoors="false">
-		<gibs amount="0" blood="0" bone="0" eye="0" gut="0" large="0" />
-	</entity>
-</entities>

--- a/descriptions/ab+/en_us.lua
+++ b/descriptions/ab+/en_us.lua
@@ -777,7 +777,7 @@ EID.descriptions[languageCode].pills={
 	{"6", "Health Down", "↓ Health down"},
 	{"7", "Health Up", "↑ Health up"},
 	{"8", "I Found Pills", "No effect"},
-	{"9", "Puberty", "Eating 3 will give you the {{}} Adult transformation (+1 Red Heart)"},
+	{"9", "Puberty", "No effect#Eating 3 will give you the Adult transformation (+1 Red Heart)"},
 	{"10", "Pretty Fly", "Adds 1 fly orbital"},
 	{"11", "Range Down", "↓ -2 Range down"},
 	{"12", "Range Up", "↑ +2.5 Range up"},

--- a/main.lua
+++ b/main.lua
@@ -290,12 +290,15 @@ if REPENTANCE then
 		flipItemNext = false
 		if entityType == 5 and (variant == 100 or variant == 150) then
 			lastGetItemResult = {nil, Isaac.GetFrameCount(), gridIndex, nil}
-			initialItemNext = true
+			-- Pedestals in need of a random item will call GET_COLLECTIBLE; fixed pedestals (Knife Piece 1) will not
+			if subtype == 0 then initialItemNext = true
+			else lastGetItemResult[1] = subtype end
 		end
 	end
 	EID:AddCallback(ModCallbacks.MC_PRE_ROOM_ENTITY_SPAWN, EID.preRoomEntitySpawn)
 	
 	function EID:postPickupInit(entity)
+		initialItemNext = false
 		flipItemNext = true
 		lastGetItemResult[4] = entity.InitSeed
 		
@@ -787,16 +790,6 @@ function EID:setPlayer()
 	end
 end
 
-if REPENTANCE then
-	function EID:removeWrongGuppyEyeInfo(effectEntity)
-		if EID.pathCheckerEntity ~= nil and effectEntity.Parent ~= nil then
-			if GetPtrHash(effectEntity.Parent) == GetPtrHash(EID.pathCheckerEntity) then
-				effectEntity:Remove()
-			end
-		end
-	end
-	EID:AddCallback(ModCallbacks.MC_POST_EFFECT_UPDATE, EID.removeWrongGuppyEyeInfo, EffectVariant.PICKUP_GHOST)
-end
 ---------------------------------------------------------------------------
 ---------------------------On Update Function------------------------------
 
@@ -844,9 +837,8 @@ function EID:onGameUpdate()
 			return
 		end
 		if EID.pathCheckerEntity == nil then
-			EID.pathCheckerEntity = game:Spawn(17, 3169, EID.player.Position, nullVector, EID.player ,0 , 4354) -- Spawns the EID Helper entity with seed that doesnt spawn rewards
-			-- Spawns an Ultra Greed Door and makes it invisible and intangible (not fully tested yet)
-			--EID.pathCheckerEntity = game:Spawn(294, 0, EID.player.Position, nullVector, EID.player, 0, 0)
+			-- Spawns an Ultra Greed Door and makes it invisible and intangible to act as a Pathfinding NPC that can't be rerolled and has no AI
+			EID.pathCheckerEntity = game:Spawn(294, 0, EID.player.Position, nullVector, EID.player, 0, 0)
 			EID.pathCheckerEntity:ClearEntityFlags(EntityFlag.FLAG_APPEAR)
 			EID.pathCheckerEntity:AddEntityFlags (EntityFlag.FLAG_PERSISTENT | EntityFlag.FLAG_NO_STATUS_EFFECTS | EntityFlag.FLAG_NO_SPRITE_UPDATE | EntityFlag.FLAG_HIDE_HP_BAR | EntityFlag.FLAG_NO_DEATH_TRIGGER | EntityFlag.FLAG_FRIENDLY)
 			if REPENTANCE then EID.pathCheckerEntity:AddEntityFlags(EntityFlag.FLAG_NO_QUERY) end

--- a/main.lua
+++ b/main.lua
@@ -162,20 +162,18 @@ function EID:onNewFloor()
 end
 EID:AddCallback(ModCallbacks.MC_POST_NEW_LEVEL, EID.onNewFloor)
 
-if EID.Config["DisplaySacrificeInfo"] then
-	function EID:onSacrificeDamage(_, _, flags, source)
-		if game:GetRoom():GetType() == RoomType.ROOM_SACRIFICE and source.Type == 0 and flags & DamageFlag.DAMAGE_SPIKES == DamageFlag.DAMAGE_SPIKES then
-			local curRoomIndex = game:GetLevel():GetCurrentRoomIndex()
-			if EID.sacrificeCounter[curRoomIndex] == nil then
-				EID.sacrificeCounter[curRoomIndex] = 1
-			end
-			if EID.sacrificeCounter[curRoomIndex] < 12 then
-				EID.sacrificeCounter[curRoomIndex] = EID.sacrificeCounter[curRoomIndex] + 1
-			end
+function EID:onSacrificeDamage(_, _, flags, source)
+	if EID.Config["DisplaySacrificeInfo"] and game:GetRoom():GetType() == RoomType.ROOM_SACRIFICE and source.Type == 0 and flags & DamageFlag.DAMAGE_SPIKES == DamageFlag.DAMAGE_SPIKES then
+		local curRoomIndex = game:GetLevel():GetCurrentRoomIndex()
+		if EID.sacrificeCounter[curRoomIndex] == nil then
+			EID.sacrificeCounter[curRoomIndex] = 1
+		end
+		if EID.sacrificeCounter[curRoomIndex] < 12 then
+			EID.sacrificeCounter[curRoomIndex] = EID.sacrificeCounter[curRoomIndex] + 1
 		end
 	end
-	EID:AddCallback(ModCallbacks.MC_ENTITY_TAKE_DMG, EID.onSacrificeDamage, EntityType.ENTITY_PLAYER)
 end
+EID:AddCallback(ModCallbacks.MC_ENTITY_TAKE_DMG, EID.onSacrificeDamage, EntityType.ENTITY_PLAYER)
 
 ---------------------------------------------------------------------------
 ------------------------Handle ALT FLOOR CHOICE----------------------------
@@ -576,7 +574,6 @@ function EID:printDescription(desc)
 		end
 	end
 	EID:printBulletPoints(desc.Description, renderPos)
-
 end
 
 function EID:printBulletPoints(description, renderPos)
@@ -827,7 +824,7 @@ function EID:onGameUpdate()
 	end
 	
 	if not EID.Config["DisplayObstructedCardInfo"] or not EID.Config["DisplayObstructedPillInfo"] or not EID.Config["DisplayObstructedSoulstoneInfo"] then
-		if EID.lastDescriptionEntity == nil or (EID.Config["DisableObstructionOnFlight"] and EID.player.CanFly) then
+		if EID.lastDescriptionEntity == nil or EID.lastDescriptionEntity:GetData()["EID_Pathfound"] or (EID.Config["DisableObstructionOnFlight"] and EID.player.CanFly) then
 			if EID.pathCheckerEntity ~= nil then
 				EID.pathCheckerEntity:Remove()
 				EID.pathCheckerEntity = nil
@@ -851,6 +848,7 @@ function EID:onGameUpdate()
 			EID.pathCheckerEntity.Position = EID.player.Position
 			EID.hasValidWalkingpath = EID.pathCheckerEntity:ToNPC().Pathfinder:HasPathToPos(EID.lastDescriptionEntity.Position, false)
 			EID.pathfindingTo = EID.lastDescriptionEntity
+			EID.lastDescriptionEntity:GetData()["EID_Pathfound"] = EID.hasValidWalkingpath
 		end
 	end
 	
@@ -863,6 +861,7 @@ function EID:updatePathfinding()
 	EID.pathCheckerEntity.Position = EID.player.Position
 	EID.hasValidWalkingpath = EID.pathCheckerEntity:ToNPC().Pathfinder:HasPathToPos(EID.lastDescriptionEntity.Position, false)
 	EID.pathfindingTo = EID.lastDescriptionEntity
+	EID.lastDescriptionEntity:GetData()["EID_Pathfound"] = EID.hasValidWalkingpath
 end
 
 local hasShownAchievementWarning = false


### PR DESCRIPTION
* Replace unique EID pathfinder entity with an Ultra Greed Door
* This fixes the pathfinder entity being replaceable by Glitched Item effects, and enabling/disabling EID making suspended games uncontinuable
* Fix Knife Piece 1 pedestal not displaying its Flip item description
* Fix a blank markup in Puberty description

I saw absolutely no glitches or changes from making this pathfinder change in all my misc. testing and a full run to Beast. Ultra Greed/Greedier do not react to it because they create children doors that they mess with. If there's some incompatible mod out there that does weird things to all Ultra Greed Doors, well, there'll be ways around it.'

I haven't tested AB+ at all recently but I purposely chose a AB+ compatible entity and I can't see a reason this would affect AB+ differently.