### PR TITLE
Pathfinding overhaul + performance improvements

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -790,7 +790,7 @@ function EID:setPlayer()
 	end
 end
 
--- is this needed if pathchecker uses a no reward seed?
+-- is this needed if pathchecker uses a no reward seed? (and isn't even present for a render?)
 if REPENTANCE then
 	function EID:removeWrongGuppyEyeInfo(effectEntity)
 		if EID.pathCheckerEntity ~= nil and effectEntity.Parent ~= nil then
@@ -840,13 +840,14 @@ function EID:onGameUpdate()
 end
 EID:AddCallback(ModCallbacks.MC_POST_UPDATE, EID.onGameUpdate)
 
-local lastPathfindCheck = { -1, -1 }
+local lastPathfindIndex = -1
+local lastPathfindFrame = -1
 local function attemptPathfind(entity)
 	if (EID.Config["DisableObstructionOnFlight"] and EID.player.CanFly) then
 		entity:GetData()["EID_Pathfound"] = true
 		return true
 	end
-	if entity.Index == lastPathfindCheck[1] and EID.GameUpdateCount - lastPathfindCheck[2] < 30 then return false end
+	if entity.Index == lastPathfindIndex and EID.GameUpdateCount - lastPathfindFrame < 30 then return false end
 	
 	-- Spawn a custom NPC entity to attempt a pathfind to the target pickup, then remove it afterwards
 	EID.pathCheckerEntity = game:Spawn(17, 3169, EID.player.Position, nullVector, EID.player, 0, 4354)
@@ -860,9 +861,8 @@ local function attemptPathfind(entity)
 	EID.pathCheckerEntity.Position = EID.player.Position -- not needed, it spawned at our position?
 	local success = EID.pathCheckerEntity:ToNPC().Pathfinder:HasPathToPos(entity.Position, false)
 	entity:GetData()["EID_Pathfound"] = success
-	EID.pathCheckerEntity:Remove()
-	EID.pathCheckerEntity = nil
-	lastPathfindCheck = { entity.Index, EID.GameUpdateCount }
+	EID.pathCheckerEntity:Remove(); EID.pathCheckerEntity = nil
+	lastPathfindIndex = entity.Index; lastPathfindFrame = EID.GameUpdateCount
 	return success
 end
 

--- a/main.lua
+++ b/main.lua
@@ -843,7 +843,7 @@ local function attemptPathfind(entity)
 		entity:GetData()["EID_Pathfound"] = true
 		return true
 	end
-	if entity.Index == lastPathfindIndex and EID.GameUpdateCount - lastPathfindFrame < 30 then return false end
+	if entity.Index == lastPathfindIndex and EID.GameUpdateCount - lastPathfindFrame < 10 then return false end
 	
 	-- Spawn a custom NPC entity to attempt a pathfind to the target pickup, then remove it afterwards
 	pathCheckerEntity = game:Spawn(17, 3169, EID.player.Position, nullVector, EID.player, 0, 4354)

--- a/main.lua
+++ b/main.lua
@@ -30,6 +30,7 @@ EID.itemUnlockStates = {}
 EID.CraneItemType = {}
 EID.absorbedSpindown = false
 local pathsChecked = {}
+local altPathItemChecked = {}
 
 EID.GameUpdateCount = 0
 EID.GameRenderCount = 0
@@ -163,6 +164,7 @@ function EID:onNewFloor()
 		EID.bagOfCraftingFloorQuery = {}
 		EID.CraneItemType = {}
 		EID.flipItemPositions = {}
+		altPathItemChecked = {}
 	end
 end
 EID:AddCallback(ModCallbacks.MC_POST_NEW_LEVEL, EID.onNewFloor)
@@ -190,18 +192,14 @@ questionMarkSprite:LoadGraphics()
 
 function EID:IsAltChoice(pickup)
 	-- do not run this while Curse of the Blind is active, since this function is really just a "is collectible pedestal a red question mark" check
-	if EID:hasCurseBlind() then
+	if not REPENTANCE or EID:hasCurseBlind() then
 		return false
 	end
-	if pickup:GetData() == nil then
-		return false
+	if altPathItemChecked[pickup.InitSeed] ~= nil then
+		return altPathItemChecked[pickup.InitSeed]
 	end
-	if EID:getEntityData(pickup, "EID_IsAltChoice") ~= nil then
-		return EID:getEntityData(pickup, "EID_IsAltChoice")
-	end
-
-	if not REPENTANCE or game:GetRoom():GetType() ~= RoomType.ROOM_TREASURE then
-		pickup:GetData()["EID_IsAltChoice"] = false
+	if game:GetRoom():GetType() ~= RoomType.ROOM_TREASURE then
+		altPathItemChecked[pickup.InitSeed] = false
 		return false
 	end
 
@@ -209,35 +207,35 @@ function EID:IsAltChoice(pickup)
 	local name = entitySprite:GetAnimation()
 
 	if name ~= "Idle" and name ~= "ShopIdle" then
-		-- Collectible can be ignored. its definetly not hidden
-		pickup:GetData()["EID_IsAltChoice"] = false
+		-- Collectible can be ignored. It's definitely not hidden
+		altPathItemChecked[pickup.InitSeed] = false
 		return false
 	end
 	
 	questionMarkSprite:SetFrame(name,entitySprite:GetFrame())
 	-- check some point in entitySprite
-	for i = -70,0,2 do
+	for i = -50,20,3 do
 		local qcolor = questionMarkSprite:GetTexel(Vector(0,i),nullVector,1,1)
 		local ecolor = entitySprite:GetTexel(Vector(0,i),nullVector,1,1)
 		if qcolor.Red ~= ecolor.Red or qcolor.Green ~= ecolor.Green or qcolor.Blue ~= ecolor.Blue then
 			-- it is not same with question mark sprite
-			pickup:GetData()["EID_IsAltChoice"] = false
+			altPathItemChecked[pickup.InitSeed] = false
 			return false
 		end
 	end
-
+	
 	--this may be a question mark, however, we will check it again to ensure it
-	for j = -3,3,2 do
-		for i = -71,0,2 do
+	for j = -1,1,1 do
+		for i = -71,0,3 do
 			local qcolor = questionMarkSprite:GetTexel(Vector(j,i),nullVector,1,1)
 			local ecolor = entitySprite:GetTexel(Vector(j,i),nullVector,1,1)
 			if qcolor.Red ~= ecolor.Red or qcolor.Green ~= ecolor.Green or qcolor.Blue ~= ecolor.Blue then
-				pickup:GetData()["EID_IsAltChoice"] = false
+				altPathItemChecked[pickup.InitSeed] = false
 				return false
 			end
 		end
 	end
-	pickup:GetData()["EID_IsAltChoice"] = true
+	altPathItemChecked[pickup.InitSeed] = true
 	return true
 end
 


### PR DESCRIPTION
Pathfinding is now initiated by pills/cards, rather than in an update.
The entity is created if necessary, does one pathfind check, and is then removed. This should fix non-vanilla effects like Suplexing the pathfinder, glitched items replacing the pathfinder with a different entity, disabling EID making it turn into a shopkeeper, etc.

Theoretically there'd be little harm in making it a regular shopkeeper or other NPC now (I'd still like EID to not have a "content" folder...). I don't know what mods out there do something with seeing Shopkeepers spawn in MC_PRE_ENTITY_SPAWN, although if they just look for type 17, they'd be doing it to the custom pathfinder anyway. But I'll leave that for you to decide.

Positive results are stored in the entity's GetData, so true results mean no more pathfinding for that entity while in the room. If querying GetData is slow, it could also be a local table emptied on new room or floor. I don't really have a way to test cycle count of these different options so I'll leave that to you if you think it'd be a better method than GetData storage.

Unsuccessful pathfinds are rechecked every third of a second. With so many ways to remove rocks, like power bracelet or polty, I figured it's not viable to watch for a trigger to recheck.

I did add two new simple integer variables for Update and Render count rather than having to poll Isaac.GetFrameCount() or Game():GetFrameCount(), because I figured, we have a callback that is called at the same rate. Probably saves cycles, right? These can be used for future performance improvements like caching the currently displayed description for some amount of time.