### PR TITLE
Void stat increase preview 1.0 + misc

### DIFF
--- a/descriptions/ab+/en_us.lua
+++ b/descriptions/ab+/en_us.lua
@@ -496,7 +496,7 @@ EID.descriptions[languageCode].collectibles={
 	{"474", "Tonsil", "Blocks enemy projectiles"},
 	{"475", "Plan C", "!!! SINGLE USE !!!#Deals 9,999,999 damage to all enemies and kills you 3 seconds later"},
 	{"476", "D1", "Duplicates 1 random pickup in the current room"},
-	{"477", "Void", "!!! When used, consume any pedestal items in the room#Active item: Its effect will be added to Void's effect (Stacking the effects)#↑ Passive item: Small stat upgrade to a random stat"},
+	{"477", "Void", "!!! When used, consumes all pedestal items in the room#Active item: Its effect activates, and will activate every future use of Void#↑ Passive item: Small stat upgrade to two random stats"},
 	{"478", "Pause", "Freezes all enemies in the room until you start shooting again#Touching a frozen enemy will hurt you#Enemies unfreeze after 30 seconds"},
 	{"479", "Smelter", "Consumes your trinket and gives you the effect permanently#More trinkets appear"},
 	{"480", "Compost", "Converts pickups into blue flies or spiders#Doubles your current blue flies/spiders#Spawns 1 blue fly or spider when you don't have any"},
@@ -869,6 +869,9 @@ EID.descriptions[languageCode].transformations={
 
 
 ---------- MISC ----------
+
+EID.descriptions[languageCode].VoidText = "If absorbed, gain:"
+EID.descriptions[languageCode].VoidNames = {"Speed", "Tears", "Damage", "Range", "Shot Speed", "Luck"}
 
 EID.descriptions[languageCode].MCM = {
 	DemoObjectName = "Demo Object Name",

--- a/descriptions/rep/en_us.lua
+++ b/descriptions/rep/en_us.lua
@@ -188,6 +188,7 @@ local repCollectibles={
 	[472] = {"472", "King Baby", "Other familiars follow it and shoot automatically at enemies#Stops moving when you are shooting#Will teleport back to you when you stop shooting"}, -- King Baby
 	[474] = {"474", "Broken Glass Cannon", "Turns into Glass Cannon when used"}, -- Broken Glass Cannon
 	[476] =	{"476", "D1", "Duplicates 1 random pickup in the current room#Duplicated pickups may not be identical to the original"}, -- D1
+	[477] = {"477", "Void", "!!! When used, consumes all pedestal items in the room#Active item: Its effect will activate every future use of Void#↑ Passive item: Small stat upgrade to two random stats"},
 	[489] = {"489", "D Infinity", "Acts as any die item except for {{Collectible723}}Spindown Dice#Change the current die with the drop key#Charge time varies based on the current die and updates when used"}, -- D Infinity
 	[491] = {"491", "Acid Baby", "Drops a random pill every 7 rooms#Using a pill poisons all enemies in the room"}, -- Acid Baby
 	[493] = {"493", "Adrenaline", "↑ Damage up for every empty Red Heart container#Follows a formula, some examples are:#+0.3 at 1#+0.92 at 2#+1.76 at 3#+2.79 at 4#+3.98 at 5"}, -- Adrenaline
@@ -1011,6 +1012,9 @@ EID.descriptions[languageCode].GlitchedItemText = {
 
 ---------- Misc. Text ----------
 
+-- Void stat names: Replace "Tears" with "Fire Rate"
+EID.descriptions[languageCode].VoidNames[2] = EID.descriptions[languageCode].GlitchedItemText[1]
+
 EID.descriptions[languageCode].spindownError = "Item disappears"
 
 EID.descriptions[languageCode].CraftingBagContent = "Bag:"
@@ -1030,7 +1034,7 @@ EID.descriptions[languageCode].BlankCardCharge = "Blank Card charge:"
 EID.descriptions[languageCode].BlankCardQCard = "Teleport to I Am Error Room#Blank Card and ?-Card will be destroyed"
 EID.descriptions[languageCode].ClearRuneCharge = "Clear Rune charge:"
 EID.descriptions[languageCode].PlaceboCharge = "Placebo charge:"
-EID.descriptions[languageCode].FlipItemToggleInfo = "(Hold {{ButtonSelect}} to show description)"
+EID.descriptions[languageCode].FlipItemToggleInfo = "(Hold {{ButtonSelect}} (Map) to show description)"
 
 
 EID.descriptions[languageCode].FalsePHDHeart = "Spawns 1 Black Heart"

--- a/eid_config.lua
+++ b/eid_config.lua
@@ -30,9 +30,9 @@ EID.UserConfig = {
 	-- Change the size of the info boxes. Range: [0,...,1]
 	-- Default = 1
 	["Scale"] = 1,
-	-- Press or hold the key to change scale.
-	-- Default = Keyboard.KEY_F5
-	["ScaleKey"] = Keyboard.KEY_F5,
+	-- Press or hold the key to change scale. Keyboard.KEY_F5 is recommended
+	-- Default = none
+	["ScaleKey"] = -1,
 	-- Set the background transparency. Range: [0,...,1]
 	-- Default = 0.75
 	["Transparency"] = 0.75,
@@ -226,6 +226,11 @@ EID.UserConfig = {
 	-- REPENTANCE ONLY!!!
 	-- Default = true
 	["DisplayCraneInfo"] = true,
+	
+	---------- Void Stat Increases ----------
+	-- Toggle display of what stats will increase on Void absorption
+	-- Default = false
+	["DisplayVoidStatInfo"] = false,
 
 	---------- Bag of Crafting ------------
 
@@ -347,7 +352,7 @@ EID.DefaultConfig = {
 	["FontType"] = "default",
 	["TextboxWidth"] = 130,
 	["Scale"] = 1,
-	["ScaleKey"] = Keyboard.KEY_F5,
+	["ScaleKey"] = -1,
 	["Transparency"] = 0.75,
 	["HUDOffset"] = 10,
 	["XPosition"] = 60,
@@ -396,6 +401,7 @@ EID.DefaultConfig = {
 	["DisplayDiceInfo"] = true,
 	["DisplayBagOfCrafting"] = "always",
 	["DisplayCraneInfo"] = true,
+	["DisplayVoidStatInfo"] = false,
 	["BagOfCraftingResults"] = 7,
 	["BagOfCraftingCombinationMax"] = 12,
 	["BagOfCraftingRandomResults"] = 400,

--- a/eid_modifiers.lua
+++ b/eid_modifiers.lua
@@ -1,6 +1,107 @@
-if REPENTANCE then
-	local game = Game()
+local game = Game()
 
+-- Afterbirth+ modifiers
+local collectiblesToCheck = { CollectibleType.COLLECTIBLE_VOID, }
+-- Repentance modifiers
+if REPENTANCE then collectiblesToCheck = { CollectibleType.COLLECTIBLE_VOID,
+	CollectibleType.COLLECTIBLE_BINGE_EATER, CollectibleType.COLLECTIBLE_BOOK_OF_VIRTUES, CollectibleType.COLLECTIBLE_SPINDOWN_DICE, 
+	CollectibleType.COLLECTIBLE_TAROT_CLOTH, CollectibleType.COLLECTIBLE_MOMS_BOX,
+	CollectibleType.COLLECTIBLE_BLANK_CARD, CollectibleType.COLLECTIBLE_CLEAR_RUNE, CollectibleType.COLLECTIBLE_PLACEBO, 
+	CollectibleType.COLLECTIBLE_FALSE_PHD, CollectibleType.COLLECTIBLE_ABYSS, CollectibleType.COLLECTIBLE_FLIP,
+} end
+local collectiblesOwned = {}
+local blackRuneOwned = false
+local lastCheck = 0
+
+local function CheckPlayersCollectibles()
+	-- recheck the players' owned collectibles periodically, not every frame
+	if EID.GameUpdateCount >= lastCheck + 15 then
+		lastCheck = EID.GameUpdateCount
+		local numPlayers = game:GetNumPlayers()
+		local players = {}; for i = 0, numPlayers - 1 do players[i] = Isaac.GetPlayer(i) end
+		for _,v in ipairs(collectiblesToCheck) do
+			collectiblesOwned[v] = false
+			for i = 0, numPlayers - 1 do
+				if players[i]:HasCollectible(v) then
+					collectiblesOwned[v] = true
+					break
+				end
+			end
+		end
+		blackRuneOwned = false
+		for i = 0, numPlayers - 1 do
+			for j = 0, 1 do
+				if players[i]:GetCard(j) == Card.RUNE_BLACK then
+					blackRuneOwned = true
+					break
+				end
+			end
+		end
+		-- Birthright Book of Belial
+		-- Could this be changed to just checking for having Collectible 59? (Check interaction with Clicker etc)
+		if REPENTANCE then
+			collectiblesOwned[59] = false
+			for i = 0, numPlayers - 1 do
+				local playerType = players[i]:GetPlayerType()
+				if (playerType == PlayerType.PLAYER_JUDAS or playerType == PlayerType.PLAYER_BLACKJUDAS) and players[i]:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
+					collectiblesOwned[59] = true
+					break
+				end
+			end
+		end
+	end
+end
+
+-- Handle Void (the only modifier that is applied to AB+ at the moment)
+-- Speed, Tears, Damage, Range, Shot Speed, Luck
+local voidIntro = EID:getDescriptionEntry("VoidText")
+local voidNames = EID:getDescriptionEntry("VoidNames")
+local voidStatUps = { 0.2, 0.5, 1, 0.5, 0.2, 1 }
+if REPENTANCE then voidStatUps[4] = 1.5 end
+
+local function VoidCallback(descObj)
+	if EID.itemConfig:GetCollectible(descObj.ObjSubType).Type ~= 3 then
+		EID:appendToDescription(descObj, "#{{Collectible477}} " .. voidIntro .. "#")
+		for i,v in ipairs(EID.VoidStatIncreases) do
+			if v > 0 then
+				EID:appendToDescription(descObj, "{{Collectible477}} +" .. v*voidStatUps[i] .. " " .. voidNames[i] .. "#")
+			end
+		end
+	end
+	return descObj
+end
+local function BlackRuneCallback(descObj)
+	EID:appendToDescription(descObj, "#{{Card41}} " .. voidIntro .. "#")
+	for i,v in ipairs(EID.BlackRuneStatIncreases) do
+		if v > 0 then
+			EID:appendToDescription(descObj, "{{Card41}} +" .. v*voidStatUps[i] .. " " .. voidNames[i] .. "#")
+		end
+	end
+	return descObj
+end
+
+local function EIDConditionsAB(descObj)
+	-- currently, only pickup descriptions have modifiers
+	if descObj.ObjType ~= 5 then return false end
+	
+	CheckPlayersCollectibles()
+	
+	local callbacks = {}
+	
+	-- Collectible Pedestal Callbacks
+	if descObj.ObjVariant == PickupVariant.PICKUP_COLLECTIBLE then
+		if EID.Config["DisplayVoidStatInfo"] then
+			if collectiblesOwned[477] then table.insert(callbacks, VoidCallback) end
+			if blackRuneOwned then table.insert(callbacks, BlackRuneCallback) end
+		end
+	end
+	
+	return callbacks
+end
+EID:addDescriptionModifier("EID Afterbirth+", EIDConditionsAB, nil)
+
+
+if REPENTANCE then
 	-- Handle Birthright
 	local function BirthrightCallback(descObj)
 		descObj.Description = ""
@@ -275,44 +376,11 @@ if REPENTANCE then
 	-- This one-condition setup fixes that and can only help performance
 	-- It also allows us to pick the order that modifiers are appended to descriptions (stats/effects first, then reroll/flip/recharge info)
 	
-	local collectiblesToCheck = { CollectibleType.COLLECTIBLE_BINGE_EATER, CollectibleType.COLLECTIBLE_BOOK_OF_VIRTUES,
-		CollectibleType.COLLECTIBLE_SPINDOWN_DICE, CollectibleType.COLLECTIBLE_VOID,
-		CollectibleType.COLLECTIBLE_TAROT_CLOTH, CollectibleType.COLLECTIBLE_MOMS_BOX,
-		CollectibleType.COLLECTIBLE_BLANK_CARD, CollectibleType.COLLECTIBLE_CLEAR_RUNE, CollectibleType.COLLECTIBLE_PLACEBO, 
-		CollectibleType.COLLECTIBLE_FALSE_PHD, CollectibleType.COLLECTIBLE_ABYSS, CollectibleType.COLLECTIBLE_FLIP,
-	}
-	local collectiblesOwned = {}
-	local lastCheck = 0
-	
 	local function EIDConditions(descObj)
 		-- currently, only pickup descriptions have modifiers
 		if descObj.ObjType ~= 5 then return false end
 		
-		-- recheck the players' owned collectibles periodically, not every frame
-		if EID.GameUpdateCount >= lastCheck + 15 then
-			lastCheck = EID.GameUpdateCount
-			local numPlayers = game:GetNumPlayers()
-			local players = {}; for i = 0, numPlayers - 1 do players[i] = Isaac.GetPlayer(i) end
-			for _,v in ipairs(collectiblesToCheck) do
-				collectiblesOwned[v] = false
-				for i = 0, numPlayers - 1 do
-					if players[i]:HasCollectible(v) then
-						collectiblesOwned[v] = true
-						break
-					end
-				end
-			end
-			-- Birthright Book of Belial
-			collectiblesOwned[59] = false
-			for i = 0, numPlayers - 1 do
-				local playerType = players[i]:GetPlayerType()
-				if (playerType == PlayerType.PLAYER_JUDAS or playerType == PlayerType.PLAYER_BLACKJUDAS) and players[i]:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
-					collectiblesOwned[59] = true
-					break
-				end
-			end
-			
-		end
+		CheckPlayersCollectibles()
 		
 		local callbacks = {}
 		

--- a/eid_modifiers.lua
+++ b/eid_modifiers.lua
@@ -282,13 +282,15 @@ if REPENTANCE then
 		CollectibleType.COLLECTIBLE_FALSE_PHD, CollectibleType.COLLECTIBLE_ABYSS, CollectibleType.COLLECTIBLE_FLIP,
 	}
 	local collectiblesOwned = {}
-
+	local lastCheck = 0
+	
 	local function EIDConditions(descObj)
 		-- currently, only pickup descriptions have modifiers
 		if descObj.ObjType ~= 5 then return false end
 		
 		-- recheck the players' owned collectibles periodically, not every frame
-		if game:GetFrameCount() % 10 == 0 then
+		if EID.GameUpdateCount >= lastCheck + 15 then
+			lastCheck = EID.GameUpdateCount
 			local numPlayers = game:GetNumPlayers()
 			local players = {}; for i = 0, numPlayers - 1 do players[i] = Isaac.GetPlayer(i) end
 			for _,v in ipairs(collectiblesToCheck) do

--- a/eid_modifiers.lua
+++ b/eid_modifiers.lua
@@ -50,6 +50,7 @@ if REPENTANCE then
 		return descObj
 	end
 	
+	local inSpindownPreview = false
 	-- Handle Spindown Dice description addition
 	local function SpindownDiceCallback(descObj)
 		EID:appendToDescription(descObj, "#{{Collectible723}} :")
@@ -63,6 +64,12 @@ if REPENTANCE then
 			end
 			refID = spinnedID
 			if refID > 0 and refID < 4294960000 then
+				if i == 1 and Input.IsActionPressed(ButtonAction.ACTION_MAP, EID.player.ControllerIndex) then
+					inSpindownPreview = true
+					local descEntry = EID:getDescriptionObj(5, 100, refID)
+					inSpindownPreview = false
+					return descEntry
+				end
 				EID:appendToDescription(descObj, "{{Collectible"..refID.."}}")
 				if EID.itemUnlockStates[refID] == false then EID:appendToDescription(descObj, "?") end
 				if i ~= EID.Config["SpindownDiceResults"] then
@@ -77,6 +84,7 @@ if REPENTANCE then
 		if hasCarBattery then
 			EID:appendToDescription(descObj, " (Results with {{Collectible356}})")
 		end
+		EID:appendToDescription(descObj, "#{{Blank}} ".. EID:getDescriptionEntry("FlipItemToggleInfo"))
 		return descObj
 	end
 	
@@ -317,7 +325,7 @@ if REPENTANCE then
 			if collectiblesOwned[584] then table.insert(callbacks, BookOfVirtuesCallback) end
 			if collectiblesOwned[706] then table.insert(callbacks, AbyssCallback) end
 			
-			if collectiblesOwned[723] or (EID.absorbedSpindown and collectiblesOwned[477]) then table.insert(callbacks, SpindownDiceCallback) end
+			if (collectiblesOwned[723] or (EID.absorbedSpindown and collectiblesOwned[477])) and not inSpindownPreview then table.insert(callbacks, SpindownDiceCallback) end
 			if collectiblesOwned[711] and EID:getEntityData(descObj.Entity, "EID_FlipItemID") then table.insert(callbacks, FlipCallback) end
 		-- Card / Rune Callbacks
 		elseif descObj.ObjVariant == PickupVariant.PICKUP_TAROTCARD then

--- a/eid_tmtrainer.lua
+++ b/eid_tmtrainer.lua
@@ -127,10 +127,10 @@ local function CheckLogForItems(_)
 			numEffects = numEffects - 1
 			eidDesc = eidDesc .. parseEffectLine(line)
 			if numEffects == 0 then
-				-- Glowing Hour Glass type effects seem to cause the game to reload all items, check if our desc is equal to the first one
+				eidDesc = EID:CheckGlitchedItemConfig(maxNumber - spawnedItems) .. eidDesc
+				-- Glowing Hour Glass type effects cause the game to reload all items, check if our desc is equal to the first one
 				if (descOne == eidDesc) then spawnedItems = 1 end
 				
-				eidDesc = EID:CheckGlitchedItemConfig(maxNumber - spawnedItems) .. eidDesc
 				EID:addCollectible(maxNumber - spawnedItems, eidDesc)
 				if spawnedItems == 1 then descOne = eidDesc end
 			end

--- a/main.lua
+++ b/main.lua
@@ -628,16 +628,7 @@ end
 local isMirrorRoom = false
 local isDeathCertRoom = false
 if REPENTANCE then
-	function EID:onNewRoom()
-		isMirrorRoom = game:GetLevel():GetCurrentRoom():IsMirrorWorld()
-		
-		local level = game:GetLevel()
-		local id = level:GetCurrentRoomIndex()
-		isDeathCertRoom = (id >=0 and GetPtrHash(level:GetRoomByIdx(id)) == GetPtrHash(level:GetRoomByIdx(id, 2)))
-		
-		-- Handle Flip Item
-		initialItemNext = false
-		flipItemNext = false
+	function EID:AssignFlipItems()
 		EID.flipMaxIndex = -1
 		local curRoomIndex = game:GetLevel():GetCurrentRoomIndex()
 		if EID.flipItemPositions[curRoomIndex] then
@@ -650,6 +641,18 @@ if REPENTANCE then
 				end
 			end
 		end
+	end
+	function EID:onNewRoom()
+		isMirrorRoom = game:GetLevel():GetCurrentRoom():IsMirrorWorld()
+		
+		local level = game:GetLevel()
+		local id = level:GetCurrentRoomIndex()
+		isDeathCertRoom = (id >=0 and GetPtrHash(level:GetRoomByIdx(id)) == GetPtrHash(level:GetRoomByIdx(id, 2)))
+		
+		-- Handle Flip Item
+		initialItemNext = false
+		flipItemNext = false
+		EID:AssignFlipItems()
 	end
 	EID:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, EID.onNewRoom)
 end
@@ -1279,6 +1282,7 @@ if EID.MCMLoaded or REPENTANCE then
 					for k, _ in pairs(configIgnoreList) do
 						savedEIDConfig[k] = nil
 					end
+					EID:AssignFlipItems()
 				end
 			end
 			

--- a/main.lua
+++ b/main.lua
@@ -862,7 +862,8 @@ local function attemptPathfind(entity)
 		pathsChecked[entity.InitSeed] = true
 		return true
 	end
-	if EID.GameUpdateCount - lastPathfindFrame < 10 then return false end
+	-- Don't reattempt pathfinding more than 3 times a second, unless this is a new entity
+	if pathsChecked[entity.InitSeed] == false and EID.GameUpdateCount - lastPathfindFrame < 10 then return false end
 	
 	-- Spawn a custom NPC entity to attempt a pathfind to the target pickup, then remove it afterwards
 	pathCheckerEntity = game:Spawn(17, 3169, EID.player.Position, nullVector, EID.player, 0, 4354)

--- a/mod_config_menu.lua
+++ b/mod_config_menu.lua
@@ -115,27 +115,27 @@ function EID:buildColorArray()
 	table.sort(colorNameArray)
 end
 
-function EID:AddBooleanSetting(category, optionName, displayText, onText, offText, infoText)
-	if (type(infoText) == "string") then infoText = {infoText} end
+function EID:AddBooleanSetting(category, optionName, displayText, params)
+	if type(params) ~= "table" then params = {} end
+	if params.repOnly and not REPENTANCE then return end
 	MCM.AddSetting(
-		"EID",
-		category,
+		"EID", category,
 		{
 			Type = ModConfigMenu.OptionType.BOOLEAN,
-			CurrentSetting = function()
+			CurrentSetting = params.currentSettingFunc or function()
 				return EID.Config[optionName]
 			end,
-			Display = function()
-				local onOff = offText
+			Display = params.displayFunc or function()
+				local onOff = params.offText or "False"
 				if EID.Config[optionName] then
-					onOff = onText
+					onOff = params.onText or "True"
 				end
 				return displayText .. ": " .. onOff
 			end,
-			OnChange = function(currentBool)
+			OnChange = params.onChangeFunc or function(currentBool)
 				EID.Config[optionName] = currentBool
 			end,
-			Info = infoText
+			Info = params.infoText or {}
 		}
 	)
 end
@@ -579,190 +579,21 @@ if MCMLoaded then
 	
 	---------------------------------------------------------------------------
 	---------------------------------Display-----------------------------------
-
-	------------Collectibles--------------
-
-	MCM.AddSetting(
-		"EID",
-		"Display",
-		{
-			Type = ModConfigMenu.OptionType.BOOLEAN,
-			CurrentSetting = function()
-				return EID.Config["DisplayItemInfo"]
-			end,
-			Display = function()
-				EID.MCMCompat_isDisplayingEIDTab = "";
-				local onOff = "False"
-				if EID.Config["DisplayItemInfo"] then
-					onOff = "True"
-				end
-				return "Collectible Infos: " .. onOff
-			end,
-			OnChange = function(currentBool)
-				EID.Config["DisplayItemInfo"] = currentBool
-			end
-		}
-	)
-	------------Trinkets--------------
-
-	MCM.AddSetting(
-		"EID",
-		"Display",
-		{
-			Type = ModConfigMenu.OptionType.BOOLEAN,
-			CurrentSetting = function()
-				return EID.Config["DisplayTrinketInfo"]
-			end,
-			Display = function()
-				local onOff = "False"
-				if EID.Config["DisplayTrinketInfo"] then
-					onOff = "True"
-				end
-				return "Trinket Infos: " .. onOff
-			end,
-			OnChange = function(currentBool)
-				EID.Config["DisplayTrinketInfo"] = currentBool
-			end
-		}
-	)
-	------------CARDS--------------
-
-	MCM.AddSetting(
-		"EID",
-		"Display",
-		{
-			Type = ModConfigMenu.OptionType.BOOLEAN,
-			CurrentSetting = function()
-				return EID.Config["DisplayCardInfo"]
-			end,
-			Display = function()
-				local onOff = "False"
-				if EID.Config["DisplayCardInfo"] then
-					onOff = "True"
-				end
-				return "Card Infos: " .. onOff
-			end,
-			OnChange = function(currentBool)
-				EID.Config["DisplayCardInfo"] = currentBool
-			end
-		}
-	)
-
-	------------PILLS--------------
-	MCM.AddSetting(
-		"EID",
-		"Display",
-		{
-			Type = ModConfigMenu.OptionType.BOOLEAN,
-			CurrentSetting = function()
-				return EID.Config["DisplayPillInfo"]
-			end,
-			Display = function()
-				local onOff = "False"
-				if EID.Config["DisplayPillInfo"] then
-					onOff = "True"
-				end
-				return "Pill Infos: " .. onOff
-			end,
-			OnChange = function(currentBool)
-				EID.Config["DisplayPillInfo"] = currentBool
-			end
-		}
-	)
-	if REPENTANCE then
-		------------Glitched Items--------------
-		MCM.AddSetting(
-			"EID",
-			"Display",
-			{
-				Type = ModConfigMenu.OptionType.BOOLEAN,
-				CurrentSetting = function()
-					return EID.Config["DisplayGlitchedItemInfo"]
-				end,
-				Display = function()
-					local onOff = "False"
-					if EID.Config["DisplayGlitchedItemInfo"] then
-						onOff = "True"
-					end
-					return "Glitched Item Infos: " .. onOff
-				end,
-				OnChange = function(currentBool)
-					EID.Config["DisplayGlitchedItemInfo"] = currentBool
-				end,
-				Info = {"Note: The --luadebug launch option is required for more detailed glitched item descriptions"}
-			}
-		)
-	end
-	--------Sacrifice Room---------
-	MCM.AddSetting(
-		"EID",
-		"Display",
-		{
-			Type = ModConfigMenu.OptionType.BOOLEAN,
-			CurrentSetting = function()
-				return EID.Config["DisplaySacrificeInfo"]
-			end,
-			Display = function()
-				local onOff = "False"
-				if EID.Config["DisplaySacrificeInfo"] then
-					onOff = "True"
-				end
-				return "Sacrifice Room Infos: " .. onOff
-			end,
-			OnChange = function(currentBool)
-				EID.Config["DisplaySacrificeInfo"] = currentBool
-			end
-		}
-	)
-
-	--------Dice Room---------
-	MCM.AddSetting(
-		"EID",
-		"Display",
-		{
-			Type = ModConfigMenu.OptionType.BOOLEAN,
-			CurrentSetting = function()
-				return EID.Config["DisplayDiceInfo"]
-			end,
-			Display = function()
-				local onOff = "False"
-				if EID.Config["DisplayDiceInfo"] then
-					onOff = "True"
-				end
-				return "Dice Room Infos: " .. onOff
-			end,
-			OnChange = function(currentBool)
-				EID.Config["DisplayDiceInfo"] = currentBool
-			end
-		}
-	)
 	
-
+	-- Simple toggles of what descriptions the user wants displayed
+	EID:AddBooleanSetting("Display", "DisplayItemInfo", "Collectible Infos")
+	EID:AddBooleanSetting("Display", "DisplayTrinketInfo", "Trinket Infos")
+	EID:AddBooleanSetting("Display", "DisplayCardInfo", "Card Infos")
+	EID:AddBooleanSetting("Display", "DisplayPillInfo", "Pill Infos")
+	EID:AddBooleanSetting("Display", "DisplayGlitchedItemInfo", "Glitched Item Infos", {repOnly = true,
+	infoText = "Note: The --luadebug launch option is required for more detailed glitched item descriptions; this can be dangerous!"})
+	EID:AddBooleanSetting("Display", "DisplaySacrificeInfo", "Sacrifice Room Infos")
+	EID:AddBooleanSetting("Display", "DisplayDiceInfo", "Dice Room Infos")
+	EID:AddBooleanSetting("Display", "DisplayCraneInfo", "Crane Game Infos", {repOnly = true})
+	EID:AddBooleanSetting("Display", "DisplayVoidStatInfo", "Void Stat Increase Infos")
 	
 	local diceSteps = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 	if REPENTANCE then
-	
-		--------Crane Game---------
-		MCM.AddSetting(
-			"EID",
-			"Display",
-			{
-				Type = ModConfigMenu.OptionType.BOOLEAN,
-				CurrentSetting = function()
-					return EID.Config["DisplayCraneInfo"]
-				end,
-				Display = function()
-					local onOff = "False"
-					if EID.Config["DisplayCraneInfo"] then
-						onOff = "True"
-					end
-					return "Crane Game Infos: " .. onOff
-				end,
-				OnChange = function(currentBool)
-					EID.Config["DisplayCraneInfo"] = currentBool
-				end
-			}
-		)
 		
 		MCM.AddSpace("EID", "Display")
 	
@@ -788,27 +619,8 @@ if MCMLoaded then
 		-- 
 		
 		-- Spindown Dice skip locked items
-		MCM.AddSetting(
-			"EID",
-			"Display",
-			{
-				Type = ModConfigMenu.OptionType.BOOLEAN,
-				CurrentSetting = function()
-					return EID.Config["SpindownDiceSkipLocked"]
-				end,
-				Display = function()
-					local onOff = "False"
-					if EID.Config["SpindownDiceSkipLocked"] then
-						onOff = "True"
-					end
-					return "Skip Locked Items: " .. onOff
-				end,
-				OnChange = function(currentBool)
-					EID.Config["SpindownDiceSkipLocked"] = currentBool
-				end,
-				Info = {"Skip locked items in the preview just as the dice will; the method to check for unlock status is not perfect, though"}
-			}
-		)
+		EID:AddBooleanSetting("Display", "SpindownDiceSkipLocked", "Skip Locked Items",
+		{repOnly = true, infoText = "Skip locked items in the preview just as the dice will; the method to check for unlock status is not perfect, though"})
 	end
 	
 	--------Obstruction---------
@@ -1369,15 +1181,13 @@ if MCMLoaded then
 			}
 		)
 		-- Bag of Crafting Hide in Battle
-		EID:AddBooleanSetting("Crafting",
-			"BagOfCraftingHideInBattle",
-			"Hide in Battle", "Yes", "No",
-			"Hides the recipe list when in a fight")
+		EID:AddBooleanSetting("Crafting", "BagOfCraftingHideInBattle", "Hide in Battle",
+		{onText = "Yes", offText = "No",
+		infoText = "Hides the recipe list when in a fight"})
 		-- Bag of Crafting 8 icons toggle
-		EID:AddBooleanSetting("Crafting",
-			"BagOfCraftingDisplayIcons",
-			"Show Recipes/Best Bag as", "8 Icons", "Groups",
-			"Choose if you want recipes (and the Best Quality bag in No Recipes Mode) shown as 8 icons, or as grouped ingredients")
+		EID:AddBooleanSetting("Crafting", "BagOfCraftingDisplayIcons", "Show Recipes/Best Bag as",
+		{onText = "8 Icons", offText = "Groups",
+		infoText = "Choose if you want recipes (and the Best Quality bag in No Recipes Mode) shown as 8 icons, or as grouped ingredients"})
 			
 		MCM.AddSpace("EID", "Crafting")
 		MCM.AddText("EID", "Crafting", function() return "Recipe List Options" end)

--- a/mod_config_menu.lua
+++ b/mod_config_menu.lua
@@ -126,6 +126,7 @@ function EID:AddBooleanSetting(category, optionName, displayText, params)
 				return EID.Config[optionName]
 			end,
 			Display = params.displayFunc or function()
+				if params.displayingTab then EID.MCMCompat_isDisplayingEIDTab = params.displayingTab end
 				local onOff = params.offText or "False"
 				if EID.Config[optionName] then
 					onOff = params.onText or "True"
@@ -581,7 +582,7 @@ if MCMLoaded then
 	---------------------------------Display-----------------------------------
 	
 	-- Simple toggles of what descriptions the user wants displayed
-	EID:AddBooleanSetting("Display", "DisplayItemInfo", "Collectible Infos")
+	EID:AddBooleanSetting("Display", "DisplayItemInfo", "Collectible Infos", {displayingTab = ""})
 	EID:AddBooleanSetting("Display", "DisplayTrinketInfo", "Trinket Infos")
 	EID:AddBooleanSetting("Display", "DisplayCardInfo", "Card Infos")
 	EID:AddBooleanSetting("Display", "DisplayPillInfo", "Pill Infos")


### PR DESCRIPTION
* Add a "Map" text to the "hold map button for preview" text (since it doesn't support non-default control mapping)
* Add the hold to preview feature to Spindown Dice
* Remove F5 being a default hotkey for the Scale toggle, since everyone keeps hitting it by accident and having no clue what to do
* Fix Glitched Item Descriptions + Glowing Hour Glass bug
* Fix Flip item descriptions not showing right after game load
* Allow entities to get an immediate pathfind check if they've never attempted one before
* Add a basic Void / Black Rune stat increase preview for 1 pedestal's worth of stats; lots of things to improve about it but I wanted to get these bug fixes in
* Started a bit of Mod Config Menu file overhaul while adding the new Void option