### PR TITLE
Bag of Crafting massive performance improvement

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -1228,3 +1228,20 @@ function EID:setModIndicatorIcon(iconMarkup, override)
 	if EID.ModIndicator[EID._currentMod].Icon ~= nil and override == false then return end
 	EID.ModIndicator[EID._currentMod].Icon = iconMarkup
 end
+
+EID.Coroutines = {}
+-- Add a coroutine to be ran 60 times a second
+function EID:addCoroutine(name, func, overwrite)
+	if overwrite or EID.Coroutines[name] == nil then EID.Coroutines[name] = coroutine.create(func) end
+end
+
+function EID:removeCoroutine(name)
+	EID.Coroutines[name] = nil
+end
+
+-- ran 60 times a second in main game render
+function EID:resumeCoroutines()
+	for k,v in pairs(EID.Coroutines) do
+		if coroutine.resume(v) == false then EID:removeCoroutine(k) end
+	end
+end

--- a/eid_bagofcrafting.lua
+++ b/eid_bagofcrafting.lua
@@ -1014,19 +1014,18 @@ function EID:handleBagOfCraftingRendering()
 		EID:printDescription(customDescObj)
 		return true
 	elseif EID.Config["BagOfCraftingDisplayMode"] == "No Recipes" then
-		EID:appendToDescription(customDescObj, getHotkeyString())
-		EID:appendToDescription(customDescObj, getFloorItemsString(false, roomItems))
-		
 		prevListDesc = ""
 		if not refreshTextbox and prevSimplifiedDesc ~= "" then
 			EID:appendToDescription(customDescObj, prevSimplifiedDesc)
 			EID:printDescription(customDescObj)
 			return true
 		end
-
-		-- The floor item text can change without our total item query string changing, so only cache what comes after that
+		
 		prevSimplifiedDesc = ""
 		refreshTextbox = false
+		
+		prevSimplifiedDesc = prevSimplifiedDesc .. getHotkeyString()
+		prevSimplifiedDesc = prevSimplifiedDesc .. getFloorItemsString(false, roomItems)
 		
 		local mostValuableBag = {}
 		for i=1,8 do
@@ -1102,6 +1101,7 @@ function EID:handleBagOfCraftingRendering()
 			upHeld = Isaac.GetTime()
 		--lock the current results so you can actually do a recipe that you've scrolled down to without losing it
 		elseif Input.IsActionTriggered(ButtonAction.ACTION_SHOOTLEFT, EID.player.ControllerIndex) then
+			refreshTextbox = true
 			if (lockedResults == nil) then lockedResults = queryString
 			else lockedResults = nil end
 		--refresh the recipes
@@ -1123,6 +1123,7 @@ function EID:handleBagOfCraftingRendering()
 			resetBagCounter = resetBagCounter + 1
 			if resetBagCounter > 120 then
 				EID.BagItems = {}
+				recheckPickups = true
 				resetBagCounter = 0
 			end
 		else
@@ -1132,9 +1133,6 @@ function EID:handleBagOfCraftingRendering()
 	--fix bug with being allowed to go to an empty page if recipe count = multiple of page size (or if we refresh on last page)
 	if (bagOfCraftingOffset >= numResults) then bagOfCraftingOffset = bagOfCraftingOffset - EID.Config["BagOfCraftingResults"] end
 	
-	EID:appendToDescription(customDescObj, getHotkeyString())
-	EID:appendToDescription(customDescObj, getFloorItemsString(true, roomItems))
-	
 	prevSimplifiedDesc = ""
 	if not refreshTextbox and prevListDesc ~= "" and bagOfCraftingOffset == prevOffset then
 		EID:appendToDescription(customDescObj, prevListDesc)
@@ -1142,10 +1140,11 @@ function EID:handleBagOfCraftingRendering()
 		return true
 	end
 	
-	-- The floor item text can change without our total item query string changing, so only cache what comes after that
 	prevListDesc = ""
 	refreshTextbox = false
 	
+	prevListDesc = prevListDesc .. getHotkeyString()
+	prevListDesc = prevListDesc .. getFloorItemsString(true, roomItems)
 	local resultDesc = EID:getDescriptionEntry("CraftingResults")
 	prevListDesc = prevListDesc .. resultDesc
 	

--- a/eid_bagofcrafting.lua
+++ b/eid_bagofcrafting.lua
@@ -269,10 +269,10 @@ function EID:simulateBagOfCrafting(componentsTable)
 		{idx = 7, weight = compCounts[30] * 10, totalWeight = 0},
 		{idx = 8, weight = compCounts[6] * 10, totalWeight = 0},
 		{idx = 9, weight = compCounts[26] * 10, totalWeight = 0},
-		{idx = 12, weight = compCounts[8] * 10}, totalWeight = 0,
+		{idx = 12, weight = compCounts[8] * 10, totalWeight = 0},
 	}
 	if compCounts[9] + compCounts[2] + compCounts[13] + compCounts[16] == 0 then
-		table.insert(poolWeights, {idx = 26, weight = compCounts[24] * 10})
+		table.insert(poolWeights, {idx = 26, weight = compCounts[24] * 10, totalWeight = 0})
 	end
 	
 	local totalWeight = 0
@@ -750,6 +750,8 @@ local function getFloorItemsString(showPreviews, roomItems)
 	end
 	return floorString
 end
+
+--local function 
 
 function EID:handleBagOfCraftingRendering()
 	local curSeed = game:GetSeeds():GetStartSeed()

--- a/eid_modifiers.lua
+++ b/eid_modifiers.lua
@@ -419,7 +419,7 @@ if REPENTANCE then
 			if collectiblesOwned[711] and EID:getEntityData(descObj.Entity, "EID_FlipItemID") then table.insert(callbacks, FlipCallback) end
 			if collectiblesOwned[723] or (EID.absorbedItems[723] and collectiblesOwned[477]) then table.insert(callbacks, SpindownDiceCallback) end
 			-- currently, only Repentance collectible modifiers have Tab previews so put it here
-			if Input.IsActionPressed(ButtonAction.ACTION_MAP, EID.player.ControllerIndex) and not inPreview then table.insert(callbacks, TabCallback) end
+			if EID.player and Input.IsActionPressed(ButtonAction.ACTION_MAP, EID.player.ControllerIndex) and not inPreview then table.insert(callbacks, TabCallback) end
 			
 		-- Card / Rune Callbacks
 		elseif descObj.ObjVariant == PickupVariant.PICKUP_TAROTCARD then

--- a/main.lua
+++ b/main.lua
@@ -944,6 +944,7 @@ EID.lastDist = 0
 local function onRender(t)
 	-- Increases by 60 per second, ignores pauses
 	EID.GameRenderCount = EID.GameRenderCount + 1
+	EID:resumeCoroutines()
 	
 	EID.isDisplaying = false
 	EID:setPlayer()


### PR DESCRIPTION
* Overhaul the pickup detection, much more immediately responsive and fixes some bag content desyncs
* Use coroutines to not drop frames while recipe crunching
* Save the object names to make the initial table sort much shorter
* Fix No Recipes Mode being broken
* Include the player's held cards/pills when tallying up the floor's pickups
* Cache the most recent Bag description text to be reused if nothing's changed since the previous frame