### PR TITLE
Add "auto" language

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -364,9 +364,9 @@ end
 -- falls back to english if it doesnt exist, unless specified otherwise
 function EID:getDescriptionEntry(objTable, objID, noFallback)
 	if not objID then
-		return EID.descriptions[EID.Config["Language"]][objTable] or EID.descriptions["en_us"][objTable]
+		return EID.descriptions[EID:getLanguage()][objTable] or EID.descriptions["en_us"][objTable]
 	else
-		local translatedTable = EID.descriptions[EID.Config["Language"]][objTable]
+		local translatedTable = EID.descriptions[EID:getLanguage()][objTable]
 		if noFallback then return translatedTable and translatedTable[objID]
 		else return (translatedTable and translatedTable[objID]) or (EID.descriptions["en_us"][objTable] and EID.descriptions["en_us"][objTable][objID]) end
 	end
@@ -450,7 +450,7 @@ function EID:getTransformationName(id)
 		-- get translated custom name
 		local customTransform = EID.CustomTransformations[id] 
 		if customTransform ~= nil then
-			return customTransform[EID.Config["Language"]] or customTransform["en_us"] or id
+			return customTransform[EID:getLanguage()] or customTransform["en_us"] or id
 		end
 		return id
 	end
@@ -1210,7 +1210,7 @@ end
 
 -- Function to fix font compatibility. Resets config font to a value compatible with your current language
 function EID:fixDefinedFont()
-	local curLang = EID.Config["Language"]
+	local curLang = EID:getLanguage()
 	local curFont = EID.Config["FontType"]
 	for _, v in ipairs(EID.descriptions[curLang].fonts) do
 		if curFont == v.name then
@@ -1224,7 +1224,7 @@ function EID:fixDefinedFont()
 end
 -- Check if a given font name is valid for the currently selected language
 function EID:canUseFontType(fontType)
-	local curLang = EID.Config["Language"]
+	local curLang = EID:getLanguage()
 	for _, v in ipairs(EID.descriptions[curLang].fonts) do
 		if fontType == v.name then
 			return true
@@ -1312,4 +1312,12 @@ function EID:checkPlayersForMissingItems()
 			EID.SaveGame[EID.Config["SaveGameNumber"]].ItemNeedsPickup[player.QueuedItem.Item.ID] = nil
 		end
 	end
+end
+
+function EID:getLanguage()
+	local lang = EID.Config["Language"]
+	if lang == "auto" then
+		return Options and EID.LanguageMap[Options.Language] or "en_us"
+	end
+	return lang
 end

--- a/eid_config.lua
+++ b/eid_config.lua
@@ -1,7 +1,8 @@
 EID.UserConfig = {
 	-------GENERAL---------
 	-- Change the language of the mod
-	-- Currently Supported: English = "en_us" (Default), "en_us_detailed" (More detailed descriptions)
+	-- Currently Supported: auto = "auto" (Default) Same as Options->Language(Rep), or English(ab+)
+	--                      English = "en_us", "en_us_detailed" (More detailed descriptions)
 	--						French = "fr"  		SPECIAL THANKS TO Nicolas Delvaux
 	--						Polish = "pl"		SPECIAL THANKS TO Rickyy
 	--						Spanish = "spa"		SPECIAL THANKS TO Lidia Arroyo Purroy
@@ -16,7 +17,7 @@ EID.UserConfig = {
 	--
 	-- If you want to make a translation, please contact me :) (wofsauge)
 	--
-	["Language"] = "en_us",
+	["Language"] = "auto",
 	-- Change if item names should be displayed in English, your translated language or both
 	-- States: 1 = English , 2 = translated,  3 = both
 	-- Default = 2
@@ -374,7 +375,7 @@ EID.UserConfig = {
 --------------------------------------------------
 
 EID.DefaultConfig = {
-	["Language"] = "en_us",
+	["Language"] = "auto",
 	["TranslateItemName"] = 2,
 	["FontType"] = "default",
 	["TextboxWidth"] = 130,

--- a/eid_data.lua
+++ b/eid_data.lua
@@ -516,3 +516,10 @@ EID.GoldenTrinketData = {
 EID.BreakUtf8CharsLanguage = {
 	['zh_cn'] = true
 }
+
+EID.LanguageMap = {
+	["ru"] = "ru",
+	["de"] = "de",
+	["kr"] = "ko_kr",
+	["zh"] = "zh_cn",
+}

--- a/main.lua
+++ b/main.lua
@@ -538,7 +538,7 @@ function EID:printDescription(desc)
 		local curName = desc.Name
 		if EID.Config["TranslateItemName"] ~= 2 then
 			local curLanguage = EID.Config["Language"]
-			if curLanguage ~= "en_us" then
+			if EID:getLanguage() ~= "en_us" then
 				EID.Config["Language"] = "en_us"
 				local englishName = desc.PermanentTextEnglish or EID:getObjectName(desc.ObjType, desc.ObjVariant, desc.ObjSubType)
 				EID.Config["Language"] = curLanguage
@@ -612,7 +612,7 @@ function EID:printBulletPoints(description, renderPos)
 	local textScale = Vector(EID.Scale, EID.Scale)
 	description = EID:replaceShortMarkupStrings(description)
 	for line in string.gmatch(description, "([^#]+)") do
-		local formatedLines = EID:fitTextToWidth(line, textboxWidth, EID.BreakUtf8CharsLanguage[EID.Config["Language"]])
+		local formatedLines = EID:fitTextToWidth(line, textboxWidth, EID.BreakUtf8CharsLanguage[EID:getLanguage()])
 		local textColor = EID:getTextColor()
 		for i, lineToPrint in ipairs(formatedLines) do
 			-- render bulletpoint

--- a/mod_config_menu.lua
+++ b/mod_config_menu.lua
@@ -280,18 +280,30 @@ if MCMLoaded then
 		{
 			Type = ModConfigMenu.OptionType.NUMBER,
 			CurrentSetting = function()
-				return AnIndexOf(EID.Languages, EID.Config["Language"])
+				if EID.Config["Language"] == "auto" then
+					return #(EID.Languages) + 1
+				else
+					return AnIndexOf(EID.Languages, EID.Config["Language"])
+				end
 			end,
 			Minimum = 1,
-			Maximum = #(EID.Languages),
+			Maximum = #(EID.Languages) + 1, -- add "auto" language
 			Display = function()
 				EID.MCMCompat_isDisplayingEIDTab = "Visuals"
-				return "Language: " .. displayLanguage[AnIndexOf(EID.Languages, EID.Config["Language"])]
+				if EID.Config["Language"] == "auto" then
+					return "Language: auto(" .. displayLanguage[AnIndexOf(EID.Languages, EID:getLanguage())] .. ")" 
+				else
+					return "Language: " .. displayLanguage[AnIndexOf(EID.Languages, EID.Config["Language"])]
+				end
 			end,
 			OnChange = function(currentNum)
 				EID.MCM_OptionChanged = true
 				EID.RefreshBagTextbox = true -- Crafting isn't open so it won't notice MCM_OptionChanged, but definitely needs to refresh
-				EID.Config["Language"] = EID.Languages[currentNum]
+				if currentNum == #(EID.Languages) + 1 then
+					EID.Config["Language"] = "auto"
+				else
+					EID.Config["Language"] = EID.Languages[currentNum]
+				end
 				local isFixed = EID:fixDefinedFont()
 				if isFixed then
 					EID:loadFont(EID.modPath .. "resources/font/eid_"..EID.Config["FontType"]..".fnt")


### PR DESCRIPTION
Added a language called `auto`. If available, EID will use the language in the Options menu to determine its display language.