### PR TITLE
Added 'addMetadata' API functions

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -80,6 +80,7 @@ function EID:addCard(id, description, itemName, language)
 end
 
 -- Adds a metadata for a card. Used for Blank Card/Clear Rune. Optional parameters: isRune
+-- Avalilable values for mimicCharge : 1~12
 function EID:addCardMetadata(id, mimicCharge, isRune)
 	if isRune then
 		EID.blankCardHidden[id] = true
@@ -98,6 +99,9 @@ function EID:addPill(id, description, itemName, language)
 end
 
 -- Adds a metadata for a pilleffect. Used for Placebo/False PHD. Optional parameters: class
+-- Avalilable values for mimicCharge : 1~12
+-- For class value, "3-" ~ "3+" are available, although False PHD only cares for negative values.
+-- "3-" : Major negative effect - Gives +0.6 Damage / "2-", "1-" : Minor negative effect - Spawns a Black Heart
 function EID:addPillMetadata(id, mimicCharge, class)
 	EID.pillMetadata[id] = {
 		mimiccharge = type(mimicCharge) == "number" and mimicCharge or -1,

--- a/eid_api.lua
+++ b/eid_api.lua
@@ -79,11 +79,30 @@ function EID:addCard(id, description, itemName, language)
 	EID.descriptions[language].custom["5.300." .. id] = {id, itemName, description, EID._currentMod}
 end
 
+-- Adds a metadata for a card. Used for Blank Card/Clear Rune. Optional parameters: isRune
+function EID:addCardMetadata(id, mimicCharge, isRune)
+	if isRune then
+		EID.blankCardHidden[id] = true
+		EID.runeIDs[id] = true
+	end
+	EID.cardMetadata[id] = {
+		mimiccharge = type(mimicCharge) == "number" and mimicCharge or -1
+	}
+end
+
 -- Adds a description for a pilleffect id. Optional parameters: itemName, language
 function EID:addPill(id, description, itemName, language)
 	itemName = itemName or nil
 	language = language or "en_us"
 	EID.descriptions[language].custom["5.70." .. id+1] = {id+1, itemName, description, EID._currentMod}
+end
+
+-- Adds a metadata for a pilleffect. Used for Placebo/False PHD. Optional parameters: class
+function EID:addPillMetadata(id, mimicCharge, class)
+	EID.pillMetadata[id] = {
+		mimiccharge = type(mimicCharge) == "number" and mimicCharge or -1,
+		class = class or "0",
+	} 
 end
 
 -- Adds a character specific description for the item "Birthright". Optional parameters: playerName, language

--- a/eid_modifiers.lua
+++ b/eid_modifiers.lua
@@ -454,7 +454,7 @@ if REPENTANCE then
 		elseif descObj.ObjVariant == PickupVariant.PICKUP_TAROTCARD then
 			if EID.collectiblesOwned[451] then table.insert(callbacks, TarotClothCallback) end
 			
-			if EID.collectiblesOwned[286] and not EID.blankCardHidden[descObj.ObjSubType] and EID.cardMetadata[descObj.ObjSubType] then table.insert(callbacks, BlankCardCallback) end
+			if EID.collectiblesOwned[286] and not EID.blankCardHidden[descObj.ObjSubType] and not EID.runeIDs[descObj.ObjSubType] and EID.cardMetadata[descObj.ObjSubType] then table.insert(callbacks, BlankCardCallback) end
 			if EID.collectiblesOwned[263] and EID.runeIDs[descObj.ObjSubType] and EID.cardMetadata[descObj.ObjSubType] then table.insert(callbacks, ClearRuneCallback) end
 		-- Pill Callbacks
 		elseif descObj.ObjVariant == PickupVariant.PICKUP_PILL then

--- a/eid_modifiers.lua
+++ b/eid_modifiers.lua
@@ -21,6 +21,9 @@ end
 EID.collectiblesOwned = {}
 EID.collectiblesAbsorbed = {}
 EID.blackRuneOwned = false
+EID.blankCardHidden = {[32]=true,[33]=true,[34]=true,[35]=true,[36]=true,[37]=true,[38]=true,[39]=true,[40]=true,[41]=true,[49]=true,[50]=true,[55]=true,[78]=true}
+EID.runeIDs = {[32]=true,[33]=true,[34]=true,[35]=true,[36]=true,[37]=true,[38]=true,[39]=true,[40]=true,[41]=true,[55]=true,[81]=true,[82]=true,[83]=true,[84]=true,[85]=true,[86]=true,[87]=true,[88]=true,[89]=true,[90]=true,[91]=true,[92]=true,[93]=true,[94]=true,[95]=true,[96]=true,[97]=true,}
+
 local lastCheck = 0
 
 function EID:CheckPlayersCollectibles()
@@ -328,11 +331,10 @@ if REPENTANCE then
 	end
 	
 	-- Handle Blank Card description addition
-	local blankCardHidden = {[32]=true,[33]=true,[34]=true,[35]=true,[36]=true,[37]=true,[38]=true,[39]=true,[40]=true,[41]=true,[49]=true,[50]=true,[55]=true,[78]=true}
 	local function BlankCardCallback(descObj)
 		local text = EID:getDescriptionEntry("BlankCardCharge")
 		local charge = EID.cardMetadata[descObj.ObjSubType]
-		if text ~= nil and charge ~= nil then
+		if text ~= nil and charge ~= nil and charge.mimiccharge ~= -1 then
 			local iconStr = "#{{Collectible286}} {{ColorSilver}}"
 			if descObj.ObjSubType == 48 then -- ? card
 				text = EID:getDescriptionEntry("BlankCardQCard")
@@ -345,11 +347,10 @@ if REPENTANCE then
 	end
 
 	-- Handle Clear Rune description addition
-	local runeIDs = {[32]=true,[33]=true,[34]=true,[35]=true,[36]=true,[37]=true,[38]=true,[39]=true,[40]=true,[41]=true,[55]=true,[81]=true,[82]=true,[83]=true,[84]=true,[85]=true,[86]=true,[87]=true,[88]=true,[89]=true,[90]=true,[91]=true,[92]=true,[93]=true,[94]=true,[95]=true,[96]=true,[97]=true,}
 	local function ClearRuneCallback(descObj)
 		local text = EID:getDescriptionEntry("ClearRuneCharge")
 		local charge = EID.cardMetadata[descObj.ObjSubType]
-		if text ~= nil and charge ~= nil then
+		if text ~= nil and charge ~= nil and charge.mimiccharge ~= -1 then
 			local iconStr = "#{{Collectible263}} {{ColorSilver}}"
 			EID:appendToDescription(descObj, iconStr..text.." {{"..charge.mimiccharge.."}}{{Battery}}")
 		end
@@ -361,7 +362,7 @@ if REPENTANCE then
 		local text = EID:getDescriptionEntry("PlaceboCharge")
 		local adjustedID = EID:getAdjustedSubtype(descObj.ObjType, descObj.ObjVariant, descObj.ObjSubType)
 		local charge = EID.pillMetadata[adjustedID-1]
-		if text ~= nil and charge ~= nil then
+		if text ~= nil and charge ~= nil and charge.mimiccharge ~= -1 then
 			local iconStr = "#{{Collectible348}} {{ColorSilver}}"
 			EID:appendToDescription(descObj, iconStr..text.." {{"..charge.mimiccharge.."}}{{Battery}}")
 		end
@@ -453,8 +454,8 @@ if REPENTANCE then
 		elseif descObj.ObjVariant == PickupVariant.PICKUP_TAROTCARD then
 			if EID.collectiblesOwned[451] then table.insert(callbacks, TarotClothCallback) end
 			
-			if EID.collectiblesOwned[286] and not blankCardHidden[descObj.ObjSubType] and descObj.ObjSubType <= 80 then table.insert(callbacks, BlankCardCallback) end
-			if EID.collectiblesOwned[263] and runeIDs[descObj.ObjSubType] then table.insert(callbacks, ClearRuneCallback) end
+			if EID.collectiblesOwned[286] and not EID.blankCardHidden[descObj.ObjSubType] and EID.cardMetadata[descObj.ObjSubType] then table.insert(callbacks, BlankCardCallback) end
+			if EID.collectiblesOwned[263] and EID.runeIDs[descObj.ObjSubType] and EID.cardMetadata[descObj.ObjSubType] then table.insert(callbacks, ClearRuneCallback) end
 		-- Pill Callbacks
 		elseif descObj.ObjVariant == PickupVariant.PICKUP_PILL then
 			if EID.collectiblesOwned[654] then table.insert(callbacks, FalsePHDCallback) end

--- a/eid_modifiers.lua
+++ b/eid_modifiers.lua
@@ -21,7 +21,7 @@ end
 EID.collectiblesOwned = {}
 EID.collectiblesAbsorbed = {}
 EID.blackRuneOwned = false
-EID.blankCardHidden = {[32]=true,[33]=true,[34]=true,[35]=true,[36]=true,[37]=true,[38]=true,[39]=true,[40]=true,[41]=true,[49]=true,[50]=true,[55]=true,[78]=true}
+EID.blankCardHidden = {[32]=true,[33]=true,[34]=true,[35]=true,[36]=true,[37]=true,[38]=true,[39]=true,[40]=true,[41]=true,[49]=true,[50]=true,[55]=true,[78]=true,[81]=true,[82]=true,[83]=true,[84]=true,[85]=true,[86]=true,[87]=true,[88]=true,[89]=true,[90]=true,[91]=true,[92]=true,[93]=true,[94]=true,[95]=true,[96]=true,[97]=true,}
 EID.runeIDs = {[32]=true,[33]=true,[34]=true,[35]=true,[36]=true,[37]=true,[38]=true,[39]=true,[40]=true,[41]=true,[55]=true,[81]=true,[82]=true,[83]=true,[84]=true,[85]=true,[86]=true,[87]=true,[88]=true,[89]=true,[90]=true,[91]=true,[92]=true,[93]=true,[94]=true,[95]=true,[96]=true,[97]=true,}
 
 local lastCheck = 0
@@ -334,7 +334,7 @@ if REPENTANCE then
 	local function BlankCardCallback(descObj)
 		local text = EID:getDescriptionEntry("BlankCardCharge")
 		local charge = EID.cardMetadata[descObj.ObjSubType]
-		if text ~= nil and charge ~= nil and charge.mimiccharge ~= -1 then
+		if text ~= nil and charge ~= nil and charge.mimiccharge and charge.mimiccharge ~= -1 then
 			local iconStr = "#{{Collectible286}} {{ColorSilver}}"
 			if descObj.ObjSubType == 48 then -- ? card
 				text = EID:getDescriptionEntry("BlankCardQCard")
@@ -350,7 +350,7 @@ if REPENTANCE then
 	local function ClearRuneCallback(descObj)
 		local text = EID:getDescriptionEntry("ClearRuneCharge")
 		local charge = EID.cardMetadata[descObj.ObjSubType]
-		if text ~= nil and charge ~= nil and charge.mimiccharge ~= -1 then
+		if text ~= nil and charge ~= nil and charge.mimiccharge and charge.mimiccharge ~= -1 then
 			local iconStr = "#{{Collectible263}} {{ColorSilver}}"
 			EID:appendToDescription(descObj, iconStr..text.." {{"..charge.mimiccharge.."}}{{Battery}}")
 		end
@@ -362,7 +362,7 @@ if REPENTANCE then
 		local text = EID:getDescriptionEntry("PlaceboCharge")
 		local adjustedID = EID:getAdjustedSubtype(descObj.ObjType, descObj.ObjVariant, descObj.ObjSubType)
 		local charge = EID.pillMetadata[adjustedID-1]
-		if text ~= nil and charge ~= nil and charge.mimiccharge ~= -1 then
+		if text ~= nil and charge ~= nil and charge.mimiccharge and charge.mimiccharge ~= -1 then
 			local iconStr = "#{{Collectible348}} {{ColorSilver}}"
 			EID:appendToDescription(descObj, iconStr..text.." {{"..charge.mimiccharge.."}}{{Battery}}")
 		end
@@ -454,7 +454,7 @@ if REPENTANCE then
 		elseif descObj.ObjVariant == PickupVariant.PICKUP_TAROTCARD then
 			if EID.collectiblesOwned[451] then table.insert(callbacks, TarotClothCallback) end
 			
-			if EID.collectiblesOwned[286] and not EID.blankCardHidden[descObj.ObjSubType] and not EID.runeIDs[descObj.ObjSubType] and EID.cardMetadata[descObj.ObjSubType] then table.insert(callbacks, BlankCardCallback) end
+			if EID.collectiblesOwned[286] and not EID.blankCardHidden[descObj.ObjSubType] and EID.cardMetadata[descObj.ObjSubType] then table.insert(callbacks, BlankCardCallback) end
 			if EID.collectiblesOwned[263] and EID.runeIDs[descObj.ObjSubType] and EID.cardMetadata[descObj.ObjSubType] then table.insert(callbacks, ClearRuneCallback) end
 		-- Pill Callbacks
 		elseif descObj.ObjVariant == PickupVariant.PICKUP_PILL then


### PR DESCRIPTION
- Added EID:addCardMetadata, EID:addPillMetadata functions. This modifies tables from eid_xmldata.lua tables, but will allow modded cards/runes/pills to add Blank Card/Clear Rune/Placebo charges without making their own modifiers.
- EID:addPillMetadata also allows adding False PHD effects for modded pills, but custom effects for False PHD still needs to be added through their own modifiers.
- Made blankCardHidden, runeIDs tables in eid_modifiers.lua global, to make these function possible.