### PR TITLE
Change default config of the more cheaty options

### DIFF
--- a/eid_config.lua
+++ b/eid_config.lua
@@ -209,8 +209,8 @@ EID.UserConfig = {
 	-- Note: The --luadebug launch option is required for more detailed glitched item descriptions
 	-- This option allows mods to have access to your files and should be turned on at your own risk!
 	-- Without --luadebug, you still can see the effect the item will have on your Hearts, and what stats it might modify
-	-- Default = true
-	["DisplayGlitchedItemInfo"] = true,
+	-- Default = false
+	["DisplayGlitchedItemInfo"] = false,
 
 	---------- Sacrifice Room ----------
 
@@ -252,8 +252,8 @@ EID.UserConfig = {
 	-- No Recipes shows percentages of what item you might get from your bag / best option on the floor, for a more intended experience
 	-- Pickups Only just shows the room/floor pickup count
 	-- (No Recipes is recommended if you have modded items)
-	-- Default = "Recipe List"
-	["BagOfCraftingDisplayMode"] = "Recipe List",
+	-- Default = "No Recipes"
+	["BagOfCraftingDisplayMode"] = "No Recipes",
 	-- Hide the recipe list when in battle
 	-- Default = true
 	["BagOfCraftingHideInBattle"] = true,
@@ -427,7 +427,7 @@ EID.DefaultConfig = {
 	["DisplayPillInfoOptions?"] = true,
 	["DisplayObstructedPillInfo"] = false,
 	["ShowUnidentifiedPillDescriptions"] = false,
-	["DisplayGlitchedItemInfo"] = true,
+	["DisplayGlitchedItemInfo"] = false,
 	["DisplaySacrificeInfo"] = true,
 	["DisplayDiceInfo"] = true,
 	["DisplayBagOfCrafting"] = "always",
@@ -440,7 +440,7 @@ EID.DefaultConfig = {
 	["BagOfCraftingDisplayNames"] = false,
 	["BagOfCraftingDisplayIcons"] = false,
 	["BagOfCraftingHideInBattle"] = true,
-	["BagOfCraftingDisplayMode"] = "Recipe List",
+	["BagOfCraftingDisplayMode"] = "No Recipes",
 	["BagOfCraftingModdedRecipes"] = true,
 	["CraftingHideKey"] = Keyboard.KEY_F3,
 	["CraftingHideButton"] = -1,


### PR DESCRIPTION
I have seen many people complain that being able to view TMTRAINER descriptions and Bag of Crafting recipes is way more cheaty than what they expect from an EID, which was made to simply save time from having to look up what an item does on the wiki.
I think way to make this better is to change the defaults, disabling TMTRAINER descriptions and setting Bag of Crafting to No Recipe mode. This way people who just download EID and want to use it out of the box won't feel bothered by this stuff while people can still enable them again if they want too.