### PR TITLE
Fix mods making REPENTANCE = false

### DIFF
--- a/eid_bagofcrafting.lua
+++ b/eid_bagofcrafting.lua
@@ -513,8 +513,7 @@ local moddedCrafting = false
 -- Check for modded items past the known max item ID on game start (can also support game updates)
 -- Only works if the new items are at Weight 1.0 in their item pools, but better than nothing
 local function GameStartCrafting()
-	if EID.Config["BagOfCraftingModdedRecipes"] and not EID:PlayersHaveCollectible(CollectibleType.COLLECTIBLE_TMTRAINER) and EID.itemConfig:GetCollectible(EID.XMLMaxItemID+1) ~= nil then
-		dofile(EID.modPath .. "eid_xmldata.lua")
+	if EID.Config["BagOfCraftingModdedRecipes"] and not EID:PlayersHaveCollectible(CollectibleType.COLLECTIBLE_TMTRAINER) and EID.itemConfig:GetCollectible(EID.XMLMaxItemID+1) ~= nil and not moddedCrafting then
 		-- Items past max ID detected
 		CraftingMaxItemID = EID.XMLMaxItemID -- XMLMaxItemID is never modified
 		-- Add new item qualities
@@ -539,11 +538,6 @@ local function GameStartCrafting()
 			itemPool:ResetRoomBlacklist()
 		end
 		moddedCrafting = true
-		sortNeeded = true
-	elseif moddedCrafting then
-		-- we had modded items; they have since been disabled
-		dofile(EID.modPath .. "eid_xmldata.lua")
-		moddedCrafting = false
 		sortNeeded = true
 	end
 end

--- a/main.lua
+++ b/main.lua
@@ -826,6 +826,11 @@ EID.RecheckVoid = false
 function EID:onGameUpdate()
 	EID.GameUpdateCount = EID.GameUpdateCount + 1
 	EID:checkPlayersForMissingItems()
+	
+	-- Fix some outdated mods erroneously setting the REPENTANCE constant to false
+	if EID.GameVersion == "rep" and REPENTANCE == false then
+		REPENTANCE = true
+	end
 
 	if collSpawned then
 		collSpawned = false


### PR DESCRIPTION
* Fix outdated mods setting the REPENTANCE constant to false, breaking rep-only EID features (item quality, alt path item hiding) and who knows what else
* Fix Bag of Crafting modded item checks unnecessarily reloading xml data; I wrote it to support mods changing in between game loads, but, EID will be reloaded from scratch if your loaded mods change anyway!