### PR TITLE
API function for adding Golden Trinket info

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -50,8 +50,9 @@ end
 -- (If it's less than 2, it also applies to doubling)
 -- Example: My modded trinket gives +0.5 range, and when tripled, adds homing instead of tripling the range boost
 -- EID:addGoldenTrinketMetadata(Isaac.GetTrinketIdByName("Cool Trinket"), {"", "Homing tears"}, 0.5, 2)
-function EID:addGoldenTrinketMetadata(id, appendText, numbersToMultiply, maxMultiplier)
+function EID:addGoldenTrinketMetadata(id, appendText, numbersToMultiply, maxMultiplier, language)
 	maxMultiplier = maxMultiplier or 3
+	language = language or "en_us"
 	
 	if appendText == "" then appendText = nil
 	elseif type(appendText) == "string" then appendText = {appendText} end
@@ -61,7 +62,7 @@ function EID:addGoldenTrinketMetadata(id, appendText, numbersToMultiply, maxMult
 	
 	EID.GoldenTrinketData[id] = {t = numbersToMultiply, mult = maxMultiplier, append = appendText and true}
 	if appendText then
-		EID.descriptions["en_us"].goldenTrinketEffects[id] = { appendText[1], appendText[1], appendText[2] or appendText[1] }
+		EID.descriptions[language].goldenTrinketEffects[id] = { appendText[1], appendText[1], appendText[2] or appendText[1] }
 	end
 end
 

--- a/eid_modifiers.lua
+++ b/eid_modifiers.lua
@@ -373,23 +373,28 @@ if REPENTANCE then
 						end
 					end)
 				end
+			end
 			--replacing a phrase, such as "half a heart"
-			elseif data.findReplace then
+			if data.findReplace then
 				local textTable = EID:getDescriptionEntry("goldenTrinketEffects", trinketID)
 				if textTable then
 					descObj.Description, count = string.gsub(descObj.Description, textTable[1], "{{ColorGold}}" .. textTable[multiplier] .. "{{ColorText}}", 1)
 				end
+			end
 			--append some new text to the description
-			elseif data.append then
+			if data.append then
 				local textTable = EID:getDescriptionEntry("goldenTrinketEffects", trinketID)
 				if textTable then
 					textChoice = math.min(textChoice, #textTable) -- some items have only 1 append description
-					descObj.Description = descObj.Description .. "#{{ColorGold}}" .. textTable[textChoice]
-					count = 1
+					if textTable[textChoice] ~= "" then
+						descObj.Description = descObj.Description .. "#{{ColorGold}}" .. textTable[textChoice]
+						count = 1
+					end
 				end
+			end
 			--the nuclear option: replacing the entire description; 1 = Gold, 2 = Mom's Box, 3 = Both
 			--only replace if the chosen language has defined it
-			elseif data.fullReplace then
+			if data.fullReplace then
 				local textTable = EID:getDescriptionEntry("goldenTrinketEffects", trinketID, true)
 				if (textTable) then
 					textChoice = math.min(textChoice, #textTable)


### PR DESCRIPTION
This adds an API function for an easy-ish way for modded trinkets to have appended text when doubled/tripled, or multiplying a number in their description, which should be the majority of use cases.
And a function to directly add a data table if someone wants the full functionality.

Also, color markup is now filtered out when checking for bulletpoint icons, since the Golden Trinket appended text starts with {{ColorGold}} and was preventing bulletpoint icons

Doing a pull request since my api function has a way bigger and more detailed comment than any other api function probably so maybe it shouldn't be that way