### PR TITLE
Fixed modded cards from EID BoC being considered as runes

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -995,6 +995,17 @@ function EID:PlayersHaveTrinket(trinketID)
 	return false
 end
 
+-- Checks if someone playing as certain character, for modifiers
+function EID:PlayersHaveCharacter(playerType)
+	for i = 0, game:GetNumPlayers() - 1 do
+		local player = Isaac.GetPlayer(i)
+		if player:GetPlayerType() == playerType then
+			return true, player
+		end
+	end
+	return false
+end
+
 -- Obtains information about glitched items from the ItemConfig (hearts added on pickup, cacheflags affected), returns string of info
 local itemConfigItemAttributes = { "AddMaxHearts", "AddHearts", "AddSoulHearts", "AddBlackHearts", "AddBombs", "AddCoins", "AddKeys", "CacheFlags" }
 function EID:CheckGlitchedItemConfig(id)

--- a/eid_bagofcrafting.lua
+++ b/eid_bagofcrafting.lua
@@ -238,7 +238,7 @@ function EID:getBagOfCraftingID(Variant, SubType)
 	elseif Variant == 300 then
 		if SubType == 0 then -- player:GetCard() returned 0
 			return nil
-		elseif SubType > 80 or (SubType >= 32 and SubType <= 41) or SubType == 55 then -- runes
+		elseif EID.runeIDs[SubType] then -- runes
 			return {23}
 		else -- cards
 			return {21}


### PR DESCRIPTION
- Unfortunately, there are no such variables to read card type in `ItemConfigCard` class, _all modded runes will be also considered as cards_ instead of runes in EID. Modders should register their modded runes through `EID:addCardMetadata`.
- Modded objects are also considered as cards(Tested with Repentance + mod)

- Added a function to detect the certain playertype(just in case)