### PR TITLE
Various transformation progress improvements

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -1566,6 +1566,7 @@ end
 
 -- Given a transformation identifier, iterate over every player and count the number of items they have which count towards that transformation
 EID.PlayerItemInteractions = {}
+local hadQueuedItem = {}
 function EID:evaluateQueuedItems()
 	for i = 0, game:GetNumPlayers() - 1 do
 		local player = Isaac.GetPlayer(i)
@@ -1573,6 +1574,11 @@ function EID:evaluateQueuedItems()
 			if not EID.PlayerItemInteractions[i] then
 				EID.PlayerItemInteractions[i] = {LastTouch = 0, actives = {}, pills = {}, altActives = {}, altPills = {}}
 			end
+			-- Refresh our descriptions upon a queued passive item being added to a player
+			if not player.QueuedItem.Item and hadQueuedItem[i] then
+				EID.ForceRefreshCache = true
+			end
+			hadQueuedItem[i] = player.QueuedItem.Item ~= nil
 			if EID.PlayerItemInteractions[i].LastTouch + 45 >= game:GetFrameCount() and player.QueuedItem.Item then
 				return
 			else

--- a/eid_api.lua
+++ b/eid_api.lua
@@ -1545,7 +1545,7 @@ function EID:evaluateTransformationProgress(transformation)
 							end
 						end
 					elseif tonumber(eVariant) == PickupVariant.PICKUP_TRINKET and player:HasTrinket(eSubType) then
-						EID.TransformationProgress[i][transformation] = EID.TransformationProgress[i][transformation] + 1
+						EID.TransformationProgress[i][transformation] = EID.TransformationProgress[i][transformation] + player:GetTrinketMultiplier(eSubType)
 					elseif tonumber(eVariant) == PickupVariant.PICKUP_PILL then
 						if EID.PlayerItemInteractions[i].pills[tostring(eSubType)] then
 							EID.TransformationProgress[i][transformation] = EID.TransformationProgress[i][transformation] + EID.PlayerItemInteractions[i].pills[tostring(eSubType)]
@@ -1557,7 +1557,7 @@ function EID:evaluateTransformationProgress(transformation)
 	end
 end
 
--- Given a transformation identifier, itterate over every player and count the number of items they have which count towards that transformation 
+-- Given a transformation identifier, iterate over every player and count the number of items they have which count towards that transformation
 EID.PlayerItemInteractions = {}
 function EID:evaluateQueuedItems()
 	for i = 0, game:GetNumPlayers() - 1 do
@@ -1573,6 +1573,7 @@ function EID:evaluateQueuedItems()
 			end
 
 			if not player.QueuedItem.Touched and player.QueuedItem.Item and player.QueuedItem.Item.Type == ItemType.ITEM_ACTIVE then
+				EID.ForceRefreshCache = true
 				local itemID = tostring(player.QueuedItem.Item.ID)
 				if not EID.PlayerItemInteractions[i].actives[itemID] then
 					EID.PlayerItemInteractions[i].actives[itemID] = 0

--- a/main.lua
+++ b/main.lua
@@ -350,6 +350,8 @@ if REPENTANCE then
 	
 	-- Before using Flip, swap all flippable pedestal's current item with the flip one (also, fix grid index if needed)
 	function EID:CheckFlipGridIndexes(collectibleType)
+		-- also, reload our descriptions due to transformation progress changing upon Flip
+		EID.ForceRefreshCache = true
 		lastFrameGridChecked = Isaac.GetFrameCount()
 		local curRoomIndex = game:GetLevel():GetCurrentRoomIndex()
 		if EID.flipItemPositions[curRoomIndex] then


### PR DESCRIPTION
* Fix Dead Tainted Lazarus and Tainted Lazarus sharing the same actives/pills tracking
* Fix D4 looking at pocket items (counting Tainted Bethany's Lemegeton every usage)
* Fix starting active items not getting counted (Judas, ???, sometimes Eden)
* Fix the cached descriptions not updating when transformation progress changes
* Fix transformation progress display not working in co-op ("EID.players" table is actually only P1 and P1's Esau; "EID.coopAllPlayers" is what you wanted; I'd agree that EID.players should be changed to what you thought it was, would need careful refactoring)