### PR TITLE
Fix Crane Game + Glowing Hour Glass (again)

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -563,7 +563,7 @@ function EID:hasDescription(entity)
 			(REPENTANCE and EID:getEntityData(entity, "EID_FlipItemID") and EID:PlayersHaveCollectible(CollectibleType.COLLECTIBLE_FLIP)))
 	end
 	if entity.Type == 6 and entity.Variant == 16 and EID.Config["DisplayCraneInfo"] and REPENTANCE then
-		isAllowed = not entity:GetSprite():IsPlaying("Broken") and not entity:GetSprite():IsPlaying("Prize") and EID.CraneItemType[tostring(entity.InitSeed)]
+		isAllowed = not entity:GetSprite():IsPlaying("Broken") and not entity:GetSprite():IsPlaying("Prize") and not entity:GetSprite():IsPlaying("OutOfPrizes") and (EID.CraneItemType[entity.InitSeed.."Drop"..entity.DropSeed] or EID.CraneItemType[tostring(entity.InitSeed)])
 	end
 	if entity.Type == 1000 then
 		if (entity.Variant == 161 and entity.SubType <= 2) or (entity.Variant == EffectVariant.DICE_FLOOR and EID.Config["DisplayDiceInfo"]) then

--- a/main.lua
+++ b/main.lua
@@ -1371,7 +1371,7 @@ local function onRender(t)
 					EID:addDescriptionToPrint(descriptionObj)
 				-- Handle Crane Game
 				elseif closest.Type == 6 and closest.Variant == 16 then
-					if EID.CraneItemType[tostring(closest.InitSeed)] then
+					if EID.CraneItemType[tostring(closest.InitSeed)] or EID.CraneItemType[closest.InitSeed.."Drop"..closest.DropSeed] then
 						if EID:getEntityData(closest, "EID_DontHide") ~= true then
 							if (EID:hasCurseBlind() and EID.Config["DisableOnCurse"]) or (game.Challenge == Challenge.CHALLENGE_APRILS_FOOL and EID.Config["DisableOnAprilFoolsChallenge"]) then
 								EID:addDescriptionToPrint({ Description = "QuestionMark", Entity = closest})


### PR DESCRIPTION
- Fix descriptions not being appeared when repairing broken Crane Game machines through Glowing Hour Glass