### PR TITLE
Fix Genesis interaction

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -1229,6 +1229,19 @@ function EID:AreAchievementsAllowed()
 	return true
 end
 
+function EID:IsDeathCertificateRoom()
+	local level = game:GetLevel()
+	local roomData = level:GetRoomByIdx(level:GetCurrentRoomIndex()).Data
+	if roomData then
+		if roomData.StageID == 35 then -- Home
+			if roomData.SubType == 33 or roomData.SubType == 34 then -- Death Certificate room subtypes
+				return true
+			end
+		end
+	end
+	return false
+end
+
 -- Converts a given table into a string containing the crafting icons of the table
 -- Example input: {1,2,3,4,5,6,7,8}
 -- Result: "{{Crafting1}}{{Crafting2}}{{Crafting3}}{{Crafting4}}{{Crafting5}}{{Crafting6}}{{Crafting7}}{{Crafting8}}"

--- a/eid_api.lua
+++ b/eid_api.lua
@@ -1231,7 +1231,7 @@ end
 
 function EID:IsDeathCertificateRoom()
 	local level = game:GetLevel()
-	local roomData = level:GetRoomByIdx(level:GetCurrentRoomIndex()).Data
+	local roomData = level:GetCurrentRoomDesc().Data
 	if roomData then
 		if roomData.StageID == 35 then -- Home ID
 			if roomData.SubType == 33 or roomData.SubType == 34 then -- Death Certificate room subtypes

--- a/eid_api.lua
+++ b/eid_api.lua
@@ -1233,7 +1233,7 @@ function EID:IsDeathCertificateRoom()
 	local level = game:GetLevel()
 	local roomData = level:GetRoomByIdx(level:GetCurrentRoomIndex()).Data
 	if roomData then
-		if roomData.StageID == 35 then -- Home
+		if roomData.StageID == 35 then -- Home ID
 			if roomData.SubType == 33 or roomData.SubType == 34 then -- Death Certificate room subtypes
 				return true
 			end

--- a/main.lua
+++ b/main.lua
@@ -740,10 +740,7 @@ if REPENTANCE then
 	end
 	function EID:onNewRoom()
 		isMirrorRoom = game:GetLevel():GetCurrentRoom():IsMirrorWorld()
-		
-		local level = game:GetLevel()
-		local id = level:GetCurrentRoomIndex()
-		isDeathCertRoom = (id >=0 and GetPtrHash(level:GetRoomByIdx(id)) == GetPtrHash(level:GetRoomByIdx(id, 2)))
+		isDeathCertRoom = EID:IsDeathCertificateRoom()
 		
 		-- Handle Flip Item
 		initialItemNext = false

--- a/main.lua
+++ b/main.lua
@@ -1505,6 +1505,12 @@ local function OnUseD4(_, _, _, player)
 end
 EID:AddCallback(ModCallbacks.MC_USE_ITEM, OnUseD4, CollectibleType.COLLECTIBLE_D4)
 
+-- Re-init transformation progress and item interactions after using Genesis
+local function OnUseGenesis(_, _, _, player)
+	OnGameStartGeneral()
+end
+EID:AddCallback(ModCallbacks.MC_USE_ITEM, OnUseGenesis, CollectibleType.COLLECTIBLE_GENESIS)
+
 function EID:OnUsePill(pillEffectID, player)
 	local playerID = EID:getPlayerID(player)
 	-- Dead Tainted Lazarus exceptions


### PR DESCRIPTION
Basically re-inits item interactions and the transformation table like it would when starting a new game.