### PR TITLE
Bag of Crafting item overfill color

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -1304,11 +1304,13 @@ function EID:tableToCraftingIconsMerged(craftTable, indicateCompleteContent)
 	for nr, count in ipairs(filteredList) do
 		if (count > 0) then
 			local coloring = ""
-			local bagContainsItem = EID:bagContainsItem(nr, count)
-			if bagContainsItem == 1 then
-				coloring = "{{ColorBagComplete}}"
-			elseif bagContainsItem == 2 then
-				coloring = "{{ColorBagOverfill}}"
+			if indicateCompleteContent then
+				local bagContainsItem = EID:bagContainsItem(nr, count)
+				if bagContainsItem == 1 then
+					coloring = "{{ColorBagComplete}}"
+				elseif bagContainsItem == 2 then
+					coloring = "{{ColorBagOverfill}}"
+				end
 			end
 			
 			iconString = iconString..coloring..count.."{{Crafting"..nr.."}}{{CR}}"
@@ -1330,7 +1332,7 @@ function EID:bagContainsItem(itemID, itemCount)
 			foundCount = foundCount + 1
 		end
 	end
-	
+
 	if foundCount == 0 then
 		return false
 	elseif foundCount < itemCount then

--- a/eid_data.lua
+++ b/eid_data.lua
@@ -639,6 +639,7 @@ EID.InlineColors = {
 	["ColorLavender"] = KColor(0.7451, 0.3686, 1, 1),
 	["ColorLightOrange"] = KColor(1, 0.6353, 0.3686, 1),
 	["ColorBagComplete"] = KColor(0, 1, 0, 0.6),
+	["ColorBagOverfill"] = KColor(1, 0.5, 0.1, 0.6),
 	-- Swag Colors
 
 	-- Rainbow color effect


### PR DESCRIPTION
Adds an orange coloration to the number of crafting ingredients when the bag contains more than the required amount.

This makes it easier to see which items can be removed from the bag when trying to craft a specific item.

![image](https://user-images.githubusercontent.com/39026963/189527316-703d2d27-621a-4f22-ae8e-55aa8607fc74.png)
Note how the number for red hearts in the crafting receipe for the Butter Bean is orange because there's more than two hearts in the bag, indicating that hearts need to be removed.