### PR TITLE
Adjusted offset for 3+ lines of hearts

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1139,11 +1139,16 @@ local function checkPosModifiers()
 		else
 			EID:removeTextPosModifier("J&E HUD")
 		end
-		-- Magdalene Birthright third row of hearts adjustment
-		if EID.player:GetPlayerType() == 1 and EID.player:HasCollectible(619) then
-			EID:addTextPosModifier("18 Heart HUD", Vector(0,5))
+		-- Magdalene Birthright, Keeper & Tainted Keeper third/fourth row of hearts adjustment
+		if EID.player:GetEffectiveMaxHearts() + EID.player:GetSoulHearts() >= 37 then
+			EID:removeTextPosModifier("18 Heart HUD")
+			EID:addTextPosModifier("24 Heart HUD", Vector(0,22))
+		elseif EID.player:GetEffectiveMaxHearts() + EID.player:GetSoulHearts() >= 25 then
+			EID:removeTextPosModifier("24 Heart HUD")
+			EID:addTextPosModifier("18 Heart HUD", Vector(0,10))
 		else
 			EID:removeTextPosModifier("18 Heart HUD")
+			EID:removeTextPosModifier("24 Heart HUD")
 		end
 	end
 end

--- a/main.lua
+++ b/main.lua
@@ -1140,10 +1140,10 @@ local function checkPosModifiers()
 			EID:removeTextPosModifier("J&E HUD")
 		end
 		-- Magdalene Birthright, Keeper & Tainted Keeper third/fourth row of hearts adjustment
-		if EID.player:GetEffectiveMaxHearts() + EID.player:GetSoulHearts() >= 37 then
+		if EID.player:GetEffectiveMaxHearts() + EID.player:GetSoulHearts() + (EID.player:GetBrokenHearts() * 2) >= 37 then
 			EID:removeTextPosModifier("18 Heart HUD")
 			EID:addTextPosModifier("24 Heart HUD", Vector(0,22))
-		elseif EID.player:GetEffectiveMaxHearts() + EID.player:GetSoulHearts() >= 25 then
+		elseif EID.player:GetEffectiveMaxHearts() + EID.player:GetSoulHearts() + (EID.player:GetBrokenHearts() * 2) >= 25 then
 			EID:removeTextPosModifier("24 Heart HUD")
 			EID:addTextPosModifier("18 Heart HUD", Vector(0,10))
 		else


### PR DESCRIPTION
- Removed Magdalene + Birthright restriction for additional row for hearts
- Now will check heart containers + soul hearts count for row check. This fixes Keeper/T.Keeper health overlapping descriptions (example image below)

![20220927103503_1](https://user-images.githubusercontent.com/37092106/192436312-8cc408c7-be13-4a6f-be6b-3ee458341f27.jpg)
![20220927103855_1](https://user-images.githubusercontent.com/37092106/192436317-571e73c9-795b-4974-a38f-84af49cde5e8.jpg)
![20220927103900_1](https://user-images.githubusercontent.com/37092106/192436318-286c02b1-7d94-49e1-b19e-5245f889575a.jpg)
