### PR TITLE
Pill Color tracking, Echo fixes, AB+ save fix

### DIFF
--- a/eid_holdmapdesc.lua
+++ b/eid_holdmapdesc.lua
@@ -91,7 +91,7 @@ function EID:getHoldMapDescription(player, checkingTwin)
 				if pickupHistory[i][4] then -- Echo chamber was owned before this card/pill was used
 					if pickupHistory[i][1] == "pill" then
 						local name = EID:getPillName(pickupHistory[i][3], false)
-						pickupNames = pickupNames .. "{{Pill}} " .. name .. "#"
+						pickupNames = pickupNames .. "{{Pill" .. pickupHistory[i][2] .. "}} " .. name .. "#"
 					else
 						local name = EID:getObjectName(5, 300, pickupHistory[i][3])
 						pickupNames = pickupNames .. "{{Card" .. pickupHistory[i][3] .. "}} " .. name .. "#"

--- a/eid_tmtrainer.lua
+++ b/eid_tmtrainer.lua
@@ -173,3 +173,10 @@ local function GameEndTMTRAINER()
 	Isaac.DebugString("[EID] Game ended; ignore previous glitched items in the log!")
 end
 EID:AddCallback(ModCallbacks.MC_PRE_GAME_EXIT, GameEndTMTRAINER)
+
+
+-- shh. it's a non-obtrusive april fools joke for the 1% of people with luadebug
+-- https://www.youtube.com/watch?v=msDuNZyYAIQ
+if (os.date("%m/%d") == "04/01") then
+	EID.descriptions["en_us"].sacrifice[1][3] = "{{Coin}} 50% chance of winning 1 coin at Sacrifice#75% chance if you're a genetic freak#!!! If you add Kurt Angle to the mix, your chances of winning drastically go down"
+end

--- a/main.lua
+++ b/main.lua
@@ -37,6 +37,7 @@ EID.CollectedItems = {}
 EID.IgnoredEntities = {}
 EID.CurrentRoomGridEntities = {}
 EID.UnidentifyablePillEffects = {} -- List of pilleffects that are always unidentifyable
+EID.UsedPillColors = {} -- Colors of pills that have been eaten during this game
 local pathsChecked = {}
 local altPathItemChecked = {}
 local alwaysUseLocalMode = false -- set to true after drawing a non-local mode description this frame
@@ -1474,7 +1475,7 @@ local function onRender(t)
 						local identified = pool:IsPillIdentified(pillColor) and not EID.Config["OnlyShowPillWhenUsedAtLeastOnce"]
 						if REPENTANCE and pillColor % PillColor.PILL_GIANT_FLAG == PillColor.PILL_GOLD then identified = true end
 						local pillEffectID = EID:getAdjustedSubtype(closest.Type, closest.Variant, pillColor)
-						local wasUsed = EID:WasPillUsed(pillEffectID, player)
+						local wasUsed = EID:WasPillUsed(pillColor)
 
 						if (identified or wasUsed or EID.Config["ShowUnidentifiedPillDescriptions"]) and not EID.UnidentifyablePillEffects[pillEffectID] then
 							local descEntry = EID:getDescriptionObj(closest.Type, closest.Variant, pillColor, closest)
@@ -1581,22 +1582,17 @@ if REPENTANCE then
 end
 
 function EID:OnUsePill(pillEffectID, player, useFlags)
-	if (REPENTANCE and player:GetPill(0) % PillColor.PILL_GIANT_FLAG == PillColor.PILL_GOLD) then return end
 	player = player or EID.player --AB+ doesn't receive player in callback arguments!
-	local playerID = EID:getPlayerID(player)
-	-- Dead Tainted Lazarus exceptions
-	local pillsTable = EID.PlayerItemInteractions[playerID].pills
-
-	if player:GetPlayerType() == 38 then
-		pillsTable = EID.PlayerItemInteractions[playerID].altPills or pillsTable
-	end
-	local effectID = tostring(pillEffectID+1)
-	if not pillsTable[effectID] then
-		pillsTable[effectID] = 0
-	end
-	pillsTable[effectID] = pillsTable[effectID] + 1
+	-- get the pill color by checking the player's pocket (not accurate for Temperance? and such, but useFlags will help us ignore those)
+	local pillColor = player:GetPill(0)
+	if pillColor == 0 then return end -- ignore if no pill found in pocket
+	EID:AddPickupToHistory("pill", pillEffectID+1, player, useFlags, pillColor) -- Echo Chamber tracking
 	
-	EID:AddPickupToHistory("pill", pillEffectID+1, player, useFlags)
+	-- for tracking used pills, ignore gold pills and noannouncer flag pills 
+	-- (not using a bitmask, because Placebo is mimic+noannouncer, and we want to count those)
+	if REPENTANCE and (pillColor % PillColor.PILL_GIANT_FLAG == PillColor.PILL_GOLD or useFlags == UseFlag.USE_NOANNOUNCER) then return end
+	EID.UsedPillColors[tostring(pillColor)] = true
+	
 end
 EID:AddCallback(ModCallbacks.MC_USE_PILL, EID.OnUsePill)
 
@@ -1617,6 +1613,7 @@ if EID.MCMLoaded or REPENTANCE then
 		["AbsorbedItems"] = true,
 		["CollectedItems"] = true,
 		["PlayerItemInteractions"] = true,
+		["UsedPillColors"] = true,
 	}
 	--------------------------------
 	--------Handle Savadata---------
@@ -1647,6 +1644,10 @@ if EID.MCMLoaded or REPENTANCE then
 			else
 				-- check for the players' starting active items
 				CheckAllActiveItemProgress()
+			end
+			EID.UsedPillColors = {}
+			if isSave then
+				EID.UsedPillColors = savedEIDConfig["UsedPillColors"] or {}
 			end
 
 			if REPENTANCE then
@@ -1735,6 +1736,7 @@ if EID.MCMLoaded or REPENTANCE then
 		end
 		EID.Config["CollectedItems"] = EID.CollectedItems
 		EID.Config["PlayerItemInteractions"] = EID.PlayerItemInteractions or {}
+		EID.Config["UsedPillColors"] = EID.UsedPillColors
 
 		EID.SaveData(EID, json.encode(EID.Config))
 		EID:hidePermanentText()


### PR DESCRIPTION
* Change pill use tracking to track Pill Color, not Pill Effect (attempt to fix issues with pills that change their effect in context)
* Pill tracking is now a global table for all players, I don't think anyone playing co-op wants selective identifying of pill descs
* Fix bugs with Echo Chamber regarding tracking Gold Pills and card/pill usages that shouldn't get tracked
* Show specific Pill icon instead of the generic {{Pill}} for Echo Chamber
* Fix AB+ requiring MCM installed to save/load data
* Fix "EID.BoC" being nil in AB+
* add a silly April Fools joke for luadebug users since they have access to the computer's date