### PR TITLE
Support Lemegeton Wisp for Item Reminder

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -982,6 +982,7 @@ end
 
 local collSpawned = false
 EID.RecheckVoid = false
+EID.ShouldCheckWisp = false
 
 function EID:onGameUpdate()
 	EID.GameUpdateCount = EID.GameUpdateCount + 1
@@ -1008,8 +1009,23 @@ function EID:onGameUpdate()
 		EID.RecheckVoid = true
 	end
 	
-	-- Remove Crane Game item data if it's giving the prize out
 	if EID.isRepentance and EID.GameUpdateCount % 10 == 0 then
+		-- Check wisp for adding reminder when using lemegeton
+		if EID.ShouldCheckWisp then
+			for _, wisp in ipairs(Isaac.FindByType(3, 237, -1, true, false)) do
+				if wisp.FrameCount < 10 then
+					local player = wisp:ToFamiliar() and wisp:ToFamiliar().Player
+					if player then
+						local playerID = EID:getPlayerID(player)
+						EID:InitItemInteractionIfAbsent(playerID)
+						table.insert(EID.RecentlyTouchedItems[playerID], wisp.SubType)
+						if (#EID.RecentlyTouchedItems[playerID] > 8) then table.remove(EID.RecentlyTouchedItems[playerID], 1) end
+					end
+					EID.ShouldCheckWisp = false
+				end
+			end
+		end
+		-- Remove Crane Game item data if it's giving the prize out
 		for _, crane in ipairs(Isaac.FindByType(6, 16, -1, true, false)) do
 			if EID.CraneItemType[tostring(crane.InitSeed)] then
 				if crane:GetSprite():IsPlaying("Prize") then
@@ -1573,6 +1589,12 @@ if EID.isRepentance then
 		CheckAllActiveItemProgress()
 	end
 	EID:AddCallback(ModCallbacks.MC_USE_ITEM, OnUseGenesis, CollectibleType.COLLECTIBLE_GENESIS)
+
+	local function OnUseLemegeton(_, _, player, _, _, _)
+		EID.ShouldCheckWisp = true
+	end
+	EID:AddCallback(ModCallbacks.MC_PRE_USE_ITEM, OnUseLemegeton, CollectibleType.COLLECTIBLE_LEMEGETON)
+
 end
 
 function EID:OnUsePill(pillEffectID, player, useFlags)

--- a/main.lua
+++ b/main.lua
@@ -1021,9 +1021,9 @@ function EID:onGameUpdate()
 						table.insert(EID.RecentlyTouchedItems[playerID], wisp.SubType)
 						if (#EID.RecentlyTouchedItems[playerID] > 8) then table.remove(EID.RecentlyTouchedItems[playerID], 1) end
 					end
-					EID.ShouldCheckWisp = false
 				end
 			end
+			EID.ShouldCheckWisp = false
 		end
 		-- Remove Crane Game item data if it's giving the prize out
 		for _, crane in ipairs(Isaac.FindByType(6, 16, -1, true, false)) do


### PR DESCRIPTION
- Allows using Lemegeton display descriptions for wisps from Item Reminder. This shares with 'Recent Items'.
- No problems for T.Laz, and J&E, and usage with Car Battery/The Battery(quick use)/Void, although usage with Car Battery requires adjusting EID config settings(EID > Reminder > Recent Items (at least max 2))

https://user-images.githubusercontent.com/37092106/235313707-9d53ff5c-eae1-4497-8154-b8656114b8e7.mp4

