### PR TITLE
Changed location of last pool name function

### DIFF
--- a/eid_mcm.lua
+++ b/eid_mcm.lua
@@ -957,7 +957,7 @@ if MCMLoaded then
 				Maximum = 1000,
 				Display = function()
 					if EID.Config["ItemPoolTextColor"] == nil then EID.Config["ItemPoolTextColor"] = EID.DefaultConfig["ItemPoolTextColor"] end
-					return "Mod Indicator: " .. string.gsub(EID.Config["ItemPoolTextColor"], "Color", "").. " ("..AnIndexOf(colorNameArray, EID.Config["ItemPoolTextColor"]).."/"..#colorNameArray..")"
+					return "Item Pool Name Color: " .. string.gsub(EID.Config["ItemPoolTextColor"], "Color", "").. " ("..AnIndexOf(colorNameArray, EID.Config["ItemPoolTextColor"]).."/"..#colorNameArray..")"
 				end,
 				OnChange = function(currentNum)
 					EID.MCM_OptionChanged = true

--- a/eid_modifiers.lua
+++ b/eid_modifiers.lua
@@ -229,19 +229,6 @@ end
 
 
 if EID.isRepentance then
-	-- Handle Last Pool
-	local function LastPoolCallback(descObj)
-		local itemConfig = EID.itemConfig:GetCollectible(descObj.ObjSubType)
-		if itemConfig:IsCollectible() and not itemConfig:HasTags(ItemConfig.TAG_QUEST) then
-			local lastPool = game:GetItemPool():GetLastPool()
-			local poolName = ""
-			local poolDescPrepend = EID:getDescriptionEntry("itemPoolFor")
-			local poolDescTable = EID:getDescriptionEntry("itemPoolNames")
-			poolName = "{{"..EID.Config["ItemPoolTextColor"].."}}"..poolDescPrepend..""..(EID.ItemPoolTypeToMarkup[lastPool] or "{{ItemPoolTreasure}}")..poolDescTable[lastPool] .. "{{CR}}#"
-			descObj.Description = poolName .. descObj.Description
-		end
-		return descObj
-	end
 	-- Handle Birthright
 	local function BirthrightCallback(descObj)
 		descObj.Description = ""
@@ -689,7 +676,6 @@ if EID.isRepentance then
 			-- Using magic numbers here in case it's slightly faster, and because the callback names give context
 			-- Check Birthright first because it overwrites the description instead of appending to it
 			if descObj.ObjSubType == 619 then table.insert(callbacks, BirthrightCallback) end
-			if not EID.InsideItemReminder and EID.Config["ShowItemPoolText"] then table.insert(callbacks, LastPoolCallback) end
 			if descObj.ObjSubType == 644 then table.insert(callbacks, ConsolationPrizeCallback) end
 			
 			if EID.collectiblesOwned[664] then table.insert(callbacks, BingeEaterCallback) end

--- a/main.lua
+++ b/main.lua
@@ -622,7 +622,7 @@ function EID:printDescription(desc, cachedID)
 	if EID.Config["ShowQuality"] and desc.Quality then
 		curName = curName.." - {{Quality"..desc.Quality.."}}"
 	end
-	-- Display Last Pool for Collectible for full reroll effects
+	-- Display Last Pool for Collectible for full reroll effects (icon)
 	if EID.isRepentance and EID.Config["ShowItemPoolIcon"] and (desc.ObjType == 5 and desc.ObjVariant == 100) then
 		local itemConfig = EID.itemConfig:GetCollectible(desc.ObjSubType)
 		if itemConfig:IsCollectible() and not itemConfig:HasTags(ItemConfig.TAG_QUEST) then
@@ -692,6 +692,21 @@ function EID:printDescription(desc, cachedID)
 			end
 		end
 	end
+	-- Display Last Pool for Collectible for full reroll effects (name)
+	if EID.isRepentance and not EID.InsideItemReminder and EID.Config["ShowItemPoolText"] and (desc.ObjType == 5 and desc.ObjVariant == 100) then
+		local itemConfig = EID.itemConfig:GetCollectible(desc.ObjSubType)
+		if itemConfig:IsCollectible() and not itemConfig:HasTags(ItemConfig.TAG_QUEST) then
+			local lastPool = game:GetItemPool():GetLastPool()
+			local itemPoolLineHeight = EID.lineHeight
+
+			local poolName = ""
+			local poolDescPrepend = EID:getDescriptionEntry("itemPoolFor")
+			local poolDescTable = EID:getDescriptionEntry("itemPoolNames")
+			poolName = "{{"..EID.Config["ItemPoolTextColor"].."}}"..poolDescPrepend..""..(EID.ItemPoolTypeToMarkup[lastPool] or "{{ItemPoolTreasure}}")..poolDescTable[lastPool] .. "{{CR}}#"
+
+			renderPos = EID:printBulletPoints(poolName, renderPos)
+		end
+	end
 	
 	if EID.Config["ShowItemDescription"] then
 		EID:printBulletPoints(desc.Description, renderPos)
@@ -724,6 +739,7 @@ function EID:printBulletPoints(description, renderPos)
 				renderPos.Y = renderPos.Y + EID.lineHeight * EID.Scale
 		end
 	end
+	return renderPos
 end
 ---------------------------------------------------------------------------
 ----------------------------Handle New Room--------------------------------


### PR DESCRIPTION
- This doesn't change anything visually for normal circumstances. (now works like Transformation text, with line breaks)
- The reason of the change is to fix possible issues within callbacks, causing Last Pool name being ended up located in wrong position.
- Made EID:printBulletPoints function return render position to make this work better.