### PR TITLE
BoC search changes/improvements

### DIFF
--- a/eid_api.lua
+++ b/eid_api.lua
@@ -511,6 +511,16 @@ function EID:getDescriptionData(Type, Variant, SubType)
 
 	return moddedDesc or legacyModdedDescription or defaultDesc
 end
+function EID:getDescriptionDataEnglish(Type, Variant, SubType)
+	local fullString = Type.."."..Variant
+	local adjustedID = EID:getAdjustedSubtype(Type, Variant, SubType)
+	local moddedDesc = EID:getDescriptionEntryEnglish("custom", fullString.."."..adjustedID)
+	local tableName = EID:getTableName(Type, Variant, SubType)
+	local legacyModdedDescription = EID:getLegacyModDescription(Type, Variant, adjustedID)
+	local defaultDesc = EID:getDescriptionEntryEnglish(tableName, adjustedID)
+
+	return moddedDesc or legacyModdedDescription or defaultDesc
+end
 
 -- Returns an adjusted SubType id for special cases like Horse Pills and Golden Trinkets
 function EID:getAdjustedSubtype(Type, Variant, SubType)

--- a/eid_bagofcrafting.lua
+++ b/eid_bagofcrafting.lua
@@ -1216,8 +1216,8 @@ function EID:handleBagOfCraftingRendering(ignoreRefreshRate)
 	for _,id in ipairs(sortedIDs) do
 		filteredRecipesList[id] = {}
 		-- Filter out item names that don't match our search term
-		local itemName = EID:getDescriptionEntry("collectibles", id)[2];
-		local englishName = EID:getDescriptionEntryEnglish("collectibles", id)[2];
+		local itemName = EID:getDescriptionData(5, 100, id)[2];
+		local englishName = EID:getDescriptionDataEnglish(5, 100, id)[2];
 		local searchValid = not EID:BoCSGetSearchEnabled() or EID:BoCSCheckItemName(itemName, englishName)
 		if (searchValid) then
 			-- If we aren't Tainted Cain, we should filter out recipes that don't use everything in our bag

--- a/eid_bagofcrafting.lua
+++ b/eid_bagofcrafting.lua
@@ -1212,28 +1212,17 @@ function EID:handleBagOfCraftingRendering(ignoreRefreshRate)
 
 	local filteredRecipesList = {}
 	local filteredNumResults = 0
-	-- If we aren't Tainted Cain, we should filter out recipes that don't use everything in our bag
-	if not IsTaintedCain() then
-		for _,id in ipairs(sortedIDs) do
-			filteredRecipesList[id] = {}
+	local tcain = IsTaintedCain()
+	for _,id in ipairs(sortedIDs) do
+		filteredRecipesList[id] = {}
+		-- Filter out item names that don't match our search term
+		local itemName = EID:getDescriptionEntry("collectibles", id)[2];
+		local englishName = EID:getDescriptionEntryEnglish("collectibles", id)[2];
+		local searchValid = not EID:BoCSGetSearchEnabled() or EID:BoCSCheckItemName(itemName, englishName)
+		if (searchValid) then
+			-- If we aren't Tainted Cain, we should filter out recipes that don't use everything in our bag
 			for _, v in ipairs(currentRecipesList[id]) do
-				local itemName = EID:getObjectName(5, 100, v[2]);
-				local searchValid = not EID:BoCSGetSearchEnabled() or EID:BoCSCheckItemName(itemName)
-
-				if (searchValid and EID:bagContainsCount(v[1]) == #bagItems) then
-					table.insert(filteredRecipesList[id], v)
-					filteredNumResults = filteredNumResults + 1
-				end
-			end
-		end
-	else
-		for _,id in ipairs(sortedIDs) do
-			filteredRecipesList[id] = {}
-			for _, v in ipairs(currentRecipesList[id]) do
-				local itemName = EID:getObjectName(5, 100, v[2]);
-				local searchValid = not EID:BoCSGetSearchEnabled() or EID:BoCSCheckItemName(itemName)
-
-				if (searchValid) then
+				if (tcain or EID:bagContainsCount(v[1]) == #bagItems) then
 					table.insert(filteredRecipesList[id], v)
 					filteredNumResults = filteredNumResults + 1
 				end


### PR DESCRIPTION
I've made some changes to the search function's Enter input based on how I think it would control best.
I would like feedback from @CreepSore and anyone else about it, especially as I think he may have had something planned with EID.BoCSLockMode which currently is only 0.

Changes:
When not in search mode: Pressing Enter will both wipe your previous search, and start a new one
(In the future there can be two configurable hotkeys bound for these; for example Backspace to clear search, but Enter to start a new one / modify your previous one)
When in search mode: Pressing Enter will save your current search
Also, unlocking no longer wipes your current search; I think you may want to keep your search when unlocking

General improvements:
Do the item name check once per item ID rather than once per recipe
Support Shift in the search input and disable regex (so ?, !, and . all work now)
Check for MCM being open
Sanitize accent marks out of item names
Check English names as well as the localized language (mostly for korean/chinese/japanese; could have a hardcoded list of languages to check english on, if other languages don't like items appearing in their searches based on english name)
Pressing Escape mid-search will cancel a search
Shorten backspace delay to more match general Windows backspace delay