### PR TITLE
Learned Recipe List + name sort + misc crafting stuff

### DIFF
--- a/descriptions/rep/en_us.lua
+++ b/descriptions/rep/en_us.lua
@@ -1159,6 +1159,8 @@ EID.descriptions[languageCode].CraftingBestQuality = "Best Quality:"
 EID.descriptions[languageCode].CraftingHideKey = "Hide:"
 EID.descriptions[languageCode].CraftingPreviewKey = "Preview:"
 EID.descriptions[languageCode].CraftingPreviewBackup = "{{Warning}} If this item's locked, it will turn into"
+-- {1} will be converted to the number of recipes
+EID.descriptions[languageCode].CraftingMore = "...+{1} more"
 
 EID.descriptions[languageCode].CraftingResults = "(Scroll: Hold {{CONFIG_BoC_Toggle}} + {{ButtonY}} {{ButtonA}}, Lock: {{ButtonX}}, Refresh: {{ButtonB}}, Reset Bag: Hold {{ButtonRB}}, Search: {{ButtonEnter}})"
 

--- a/eid_api.lua
+++ b/eid_api.lua
@@ -983,6 +983,12 @@ end
 -- returns the string as a table of lines
 function EID:fitTextToWidth(str, textboxWidth, breakUtf8Chars)
 	local formattedLines = {}
+	-- Lines with a {{NoLineBreak}} tag should be left in one continuous line
+	if str:find("{{NoLineBreak}}") then
+		str = str:gsub("{{NoLineBreak}}","")
+		table.insert(formattedLines,str)
+		return formattedLines
+	end
 	local curLength = 0
 	local text = {}
 	-- the first word we run into might actually be a bulletpoint icon, which should be zero width

--- a/eid_api.lua
+++ b/eid_api.lua
@@ -511,6 +511,16 @@ function EID:getDescriptionData(Type, Variant, SubType)
 
 	return moddedDesc or legacyModdedDescription or defaultDesc
 end
+function EID:getDescriptionDataEnglish(Type, Variant, SubType)
+	local fullString = Type.."."..Variant
+	local adjustedID = EID:getAdjustedSubtype(Type, Variant, SubType)
+	local moddedDesc = EID:getDescriptionEntryEnglish("custom", fullString.."."..adjustedID)
+	local tableName = EID:getTableName(Type, Variant, SubType)
+	local legacyModdedDescription = EID:getLegacyModDescription(Type, Variant, adjustedID)
+	local defaultDesc = EID:getDescriptionEntryEnglish(tableName, adjustedID)
+
+	return moddedDesc or legacyModdedDescription or defaultDesc
+end
 
 -- Returns an adjusted SubType id for special cases like Horse Pills and Golden Trinkets
 function EID:getAdjustedSubtype(Type, Variant, SubType)

--- a/eid_bagofcrafting.lua
+++ b/eid_bagofcrafting.lua
@@ -1216,8 +1216,8 @@ function EID:handleBagOfCraftingRendering(ignoreRefreshRate)
 	for _,id in ipairs(sortedIDs) do
 		filteredRecipesList[id] = {}
 		-- Filter out item names that don't match our search term
-		local itemName = EID:getDescriptionEntry("collectibles", id)[2];
-		local englishName = EID:getDescriptionEntryEnglish("collectibles", id)[2];
+		local itemName = EID:getDescriptionData(5, 100, id)[2];
+		local englishName = EID:getDescriptionDataEnglish(5, 100, id)[2];
 		local searchValid = not EID:BoCSGetSearchEnabled() or EID:BoCSCheckItemName(itemName, englishName)
 		if (searchValid) then
 			-- If we aren't Tainted Cain, we should filter out recipes that don't use everything in our bag

--- a/eid_bagofcrafting.lua
+++ b/eid_bagofcrafting.lua
@@ -1212,28 +1212,17 @@ function EID:handleBagOfCraftingRendering(ignoreRefreshRate)
 
 	local filteredRecipesList = {}
 	local filteredNumResults = 0
-	-- If we aren't Tainted Cain, we should filter out recipes that don't use everything in our bag
-	if not IsTaintedCain() then
-		for _,id in ipairs(sortedIDs) do
-			filteredRecipesList[id] = {}
+	local tcain = IsTaintedCain()
+	for _,id in ipairs(sortedIDs) do
+		filteredRecipesList[id] = {}
+		-- Filter out item names that don't match our search term
+		local itemName = EID:getDescriptionEntry("collectibles", id)[2];
+		local englishName = EID:getDescriptionEntryEnglish("collectibles", id)[2];
+		local searchValid = not EID:BoCSGetSearchEnabled() or EID:BoCSCheckItemName(itemName, englishName)
+		if (searchValid) then
+			-- If we aren't Tainted Cain, we should filter out recipes that don't use everything in our bag
 			for _, v in ipairs(currentRecipesList[id]) do
-				local itemName = EID:getObjectName(5, 100, v[2]);
-				local searchValid = not EID:BoCSGetSearchEnabled() or EID:BoCSCheckItemName(itemName)
-
-				if (searchValid and EID:bagContainsCount(v[1]) == #bagItems) then
-					table.insert(filteredRecipesList[id], v)
-					filteredNumResults = filteredNumResults + 1
-				end
-			end
-		end
-	else
-		for _,id in ipairs(sortedIDs) do
-			filteredRecipesList[id] = {}
-			for _, v in ipairs(currentRecipesList[id]) do
-				local itemName = EID:getObjectName(5, 100, v[2]);
-				local searchValid = not EID:BoCSGetSearchEnabled() or EID:BoCSCheckItemName(itemName)
-
-				if (searchValid) then
+				if (tcain or EID:bagContainsCount(v[1]) == #bagItems) then
 					table.insert(filteredRecipesList[id], v)
 					filteredNumResults = filteredNumResults + 1
 				end

--- a/eid_bagofcrafting_search.lua
+++ b/eid_bagofcrafting_search.lua
@@ -71,7 +71,7 @@ function EID:BoCSSetSearchInputEnabled(newState, force)
 	if EID.BoCSLockMode == 0 and EID:BoCSGetLocked() and force ~= true then
 		return
 	end
-	newState = newState and EID.Config["BagOfCraftingDisplayRecipesMode"] == "Recipe List"
+	newState = newState and EID.Config["BagOfCraftingDisplayRecipesMode"]:find("Recipe List")
 
 	searchInputEnabled = newState
 	if newState then
@@ -95,14 +95,13 @@ end
 
 --- Returns true if the item name is matched
 -- @returns boolean
-function EID:BoCSCheckItemName(itemName, englishName)
+function EID:BoCSCheckItemName(itemName)
 	if searchValue == "" then
 		return true
 	end
 	
-	-- Check the localized name and English name for matching our search string (accents removed)
+	-- Check the name for matching our search string (accents removed)
 	return string.find(sanitizeName(itemName), sanitizeName(searchValue), 1, true)
-		or string.find(sanitizeName(englishName), sanitizeName(searchValue), 1, true)
 end
 
 local function handleSearchInput()	

--- a/eid_config.lua
+++ b/eid_config.lua
@@ -371,6 +371,7 @@ EID.UserConfig = {
 	-- Display modes for the Bag of Crafting display
 	-- Options: "Recipe List", "Preview Only", "Item Probability", "Pickups Only"
 	-- The "Recipe List" is a detailed calculated list of recipes based on what you have available on the floor
+	-- "Learned Recipe List" only shows you recipes that you have discovered during that run, plus fixed recipes
 	-- "Preview Only" shows the description of the item you can currently craft in your bag
 	-- "Item Probability" shows percentages of what item you might get from your bag / best option on the floor, for a more intended experience
 	-- "Pickups Only" just shows the room/floor pickup count
@@ -382,6 +383,11 @@ EID.UserConfig = {
 	-- Show the text for the Hide/Preview and Recipe List hotkeys
 	-- Default = true
 	["BagOfCraftingShowControls"] = true,
+	-- Sort bag recipes by quality and then alphabetically (to prioritize the best possible crafts),
+	-- or just alphabetically (to more easily find specific items if you don't know their quality)
+	-- Options: "Quality", "Name"
+	-- Default = "Quality"
+	["BagOfCraftingSortOrder"] = "Quality",
 	-- Changes the amount of results shown in the Bag of Crafting description
 	-- Higher numbers can cause more lag!
 	-- Default = 7
@@ -587,6 +593,7 @@ EID.DefaultConfig = {
 	["BagOfCraftingResults"] = 7,
 	["BagOfCraftingCombinationMax"] = 12,
 	["BagOfCraftingRandomResults"] = 400,
+	["BagOfCraftingSortOrder"] = "Quality",
 	["BagOfCraftingDisplayNames"] = false,
 	["BagOfCraftingDisplayIcons"] = false,
 	["BagOfCraftingHideInBattle"] = true,

--- a/eid_mcm.lua
+++ b/eid_mcm.lua
@@ -40,9 +40,9 @@ end
 
 local function renderDummyBagOfCraftingDesc()
 	EID.bagPlayer = Isaac.GetPlayer(0)
-	EID.BoC.BagItemsOverride = {15,15,5,1,10}
-	EID.BoC.RoomOverride = {8,8,8,9}
-	EID.BoC.FloorOverride = {1,1,1,3,4,8,8,8,9}
+	EID.BoC.BagItemsOverride = {15,15,5,1,10,8,8,9}
+	EID.BoC.RoomOverride = {8,8,9}
+	EID.BoC.FloorOverride = {1,1,1,3,4,8,8}
 	EID.BoC.InventoryOverride = {21,22}
 	EID.RefreshBagTextbox = true
 	local craftingSuccess = EID:handleBagOfCraftingRendering(true)
@@ -626,9 +626,9 @@ if MCMLoaded then
 		EID:AddNumberSetting("Crafting", "DisplayBagOfCrafting", "Show Display", 1, #bagDisplays, { displayingTab = "Crafting", indexOf = bagDisplays, infoText = {"Always = Always show Results", "Hold = Show when holding up bag", "Never = Disable Bag of Crafting feature"}})
 
 		-- Bag of Crafting Display Mode
-		local bagDisplayModes = {"Recipe List","Item Probability","Preview Only","Pickups Only"}
+		local bagDisplayModes = {"Recipe List", "Learned Recipe List","Item Probability","Preview Only","Pickups Only"}
 		EID:AddNumberSetting("Crafting", "BagOfCraftingDisplayRecipesMode", "Display Mode", 1, #bagDisplayModes, { indexOf = bagDisplayModes,
-			infoText = {"Toggle showing a list of recipes, an item preview when bag is full, what item pool/quality you might get, or only the floor pickups"}})
+			infoText = {"Toggle showing list of recipes, recipes you've learned, what item pool/quality you might get, item preview when bag is full, or only floor pickups"}})
 
 		-- Bag of Crafting Hide in Battle
 		EID:AddBooleanSetting("Crafting", "BagOfCraftingHideInBattle", "Hide in Battle", {onText = "Yes", offText = "No",
@@ -643,7 +643,21 @@ if MCMLoaded then
 
 		MCM.AddSpace("EID", "Crafting")
 		MCM.AddText("EID", "Crafting", function() return "Recipe List Options" end)
-
+		
+		-- Bag of Crafting item names
+		local bagSortTypes = {"Quality", "Name"}
+		EID:AddNumberSetting("Crafting", "BagOfCraftingSortOrder", "Sort Recipes by", 1, #bagSortTypes,
+			{ indexOf = bagSortTypes, infoText = "Sort the recipe list by quality + name, or just name", onChangeFunc =
+		function(currentNum)
+			EID.MCM_OptionChanged = true
+			EID.BoC.SortNeeded = true
+			EID.Config["BagOfCraftingSortOrder"] = bagSortTypes[currentNum]
+		end})
+		
+		-- Bag of Crafting item names
+		EID:AddBooleanSetting("Crafting", "BagOfCraftingDisplayNames", "Show Item Names",
+			{ infoText = "If on, each recipe result takes two lines, one for the item name, one for the recipe"})
+		
 		-- Bag of Crafting results per page
 		local bagSteps = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 		EID:AddScrollSetting("Crafting", "BagOfCraftingResults", "Displayed Recipes", bagSteps,
@@ -658,10 +672,6 @@ if MCMLoaded then
 		local calcSteps = {200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200}
 		EID:AddScrollSetting("Crafting", "BagOfCraftingRandomResults", "Random Calculations", calcSteps,
 			{ infoText = "An additional X number of randomly chosen recipes will be checked, changing each pickup spawn/despawn or refresh"})
-
-		-- Bag of Crafting item names
-		EID:AddBooleanSetting("Crafting", "BagOfCraftingDisplayNames", "Show Item Names",
-			{ infoText = "If on, each recipe result takes two lines, one for the item name, one for the recipe"})
 
 		MCM.AddSpace("EID", "Crafting")
 


### PR DESCRIPTION
Changes:

Added "Learned Recipe List" mode that saves your recipes you learn whenever your bag is full
(Currently it shows all recipes even if they aren't creatable from what's available on the floor, which I think is fine as the list will be short and you can set goals for repeat crafts without needing the items around; but should they have some indication they're not craftable yet?)

Added sort option so you can sort by Quality or by Name
(I would like to add a Sort by Ingredients in Bag, like put 7/8 recipes at the top, but that will need more work, right now the sort is just an array of item IDs that is basically constant)

Added a markup {{NoLineBreak}} that lets a line be as long as you want, used for item names in the recipe list at the moment for long item names to be forced onto one line (we'll want to add this to stuff like pandora's box or teleport 2.0)

...+ more text is now translatable

Changed MCM preview overrides to have a full bag, for learned recipe list / preview only

The new search feature will only check English item names if it finds no recipes using the selected language's names