### PR TITLE
"Health up" soul conditionals, pocket item conditionals

### DIFF
--- a/descriptions/ab+/en_us.lua
+++ b/descriptions/ab+/en_us.lua
@@ -1023,20 +1023,20 @@ EID.descriptions[languageCode].CharacterInfo = {
 	[1] = {"Magdalene", ""},
 	[2] = {"Cain", ""},
 	[3] = {"Judas", ""},
-	[4] = {"???", "Can't have Red Hearts"},
+	[4] = {"???", "Can't have Red Hearts#{{SoulHeart}} Health ups grant Soul Hearts"},
 	[5] = {"Eve", ""},
 	[6] = {"Samson", ""},
-	[7] = {"Azazel", "Flight#Short range Brimstone instead of tears#Can gain Red Hearts"},
+	[7] = {"Azazel", "Flight#{{Collectible118}} Short range Brimstone instead of tears"},
 	[8] = {"Lazarus", "When you die, resurrect as Lazarus Risen with 1 Red Heart container"},
 	[9] = {"Eden", "Start with random stats and items each run"},
-	[10] = {"The Lost", "Flight#Spectral tears#No health#One devil deal per room can be taken for free"},
+	[10] = {"The Lost", "Flight#Spectral tears#{{Warning}} No health#{{DevilRoom}} One devil deal per room can be taken for free"},
 	[11] = {"Lazarus Risen", "Increased stats and x1.2 damage multiplier"},
-	[12] = {"Dark Judas", "x2 Damage multiplier#Can gain Red Hearts#Counts as Judas for completion marks"},
-	[13] = {"Lilith", "Cannot shoot tears#Her Incubus shoots for her"},
-	[14] = {"Keeper", "Heal by picking up coins#Heart pickups are turned into Blue Flies"},
+	[12] = {"Dark Judas", "{{Damage}} x2 Damage multiplier#{{Player3}} Counts as Judas for completion marks"},
+	[13] = {"Lilith", "Cannot shoot tears#{{Collectible360}} Her Incubus shoots for her"},
+	[14] = {"Keeper", "{{CoinHeart}} Heal by picking up coins#Maximum of 2 Coin Hearts#Heart pickups are turned into Blue Flies"},
 	[15] = {"Apollyon", ""},
-	[16] = {"The Forgotten", "You have a melee attack which can be charged and thrown#Can have up to 6 Bone Hearts#Press {{ButtonRT}} to switch to The Soul#The Soul can have up to 6 Soul/Black Hearts and has flight and spectral tears#The Soul is chained to The Forgotten, and can only move in a small radius around him"},
-	[17] = {"The Forgotten Soul", "You have a melee attack which can be charged and thrown#Can have up to 6 Bone Hearts#Press {{ButtonRT}} to switch to The Soul#The Soul can have up to 6 Soul/Black Hearts and has flight and spectral tears#The Soul is chained to The Forgotten, and can only move in a small radius around him"},
+	[16] = {"The Forgotten", "You have a melee attack which can be charged and thrown#{{BoneHeart}} Can have up to 6 Bone Hearts#{{Player17}} Press {{ButtonRT}} to switch to The Soul#{{SoulHeart}} The Soul can have up to 6 Soul/Black Hearts and has flight and spectral tears#The Soul is chained to a small radius around The Forgotten"},
+	[17] = {"The Forgotten Soul", "You have a melee attack which can be charged and thrown#{{BoneHeart}} Can have up to 6 Bone Hearts#{{Player17}} Press {{ButtonRT}} to switch to The Soul#{{SoulHeart}} The Soul can have up to 6 Soul/Black Hearts and has flight and spectral tears#The Soul is chained to a small radius around The Forgotten"},
 }
 
 ---------- Sacrifice Room ----------
@@ -1189,6 +1189,7 @@ EID.descriptions[languageCode].ConditionalDescs = {
 	["No Effect (Copies)"] = "No additional effect from multiple copies", -- Having the item already, or having Diplopia while looking at a pedestal
 	["No Effect (Familiars)"] = "No additional effect on familiars", -- probably just for Hive Mind + BFFS!
 	["No Red"] = "No effect for characters that can't have Red Hearts",
+	["Different Effect"] = "Different effect for {1}",
 	
 	
 	------ GREED MODE ------
@@ -1218,9 +1219,32 @@ EID.descriptions[languageCode].ConditionalDescs = {
 	
 	
 	------ SPECIFIC CHARACTER SYNERGIES/CHANGES ------
-	["Red to Soul"] = {"{{Heart}} +","{{SoulHeart}} +", "{{Heart}} Full health", "", "{{Heart}} Heals 1 heart", ""}, -- Red HP to Soul Hearts, removes heals
-	["Red to Coin"] = {"{{Heart}} +","{{CoinHeart}} +", "{{Heart}} Full health", "{{CoinHeart}} Full Health", "{{Heart}} Heals 1 heart", "{{CoinHeart}} Heals 1 coin"},
-
+	-- NO RED HEALTH CHARS
+	-- These change "+1 Health, Full health" to just "+1 Soul Heart" and etc.
+	["Red to Soul"] = {"↑ {{Heart}} +1 Health", "{{SoulHeart}} +1 Soul Heart", "↑ {{Heart}} +2 Health", "{{SoulHeart}} +2 Soul Hearts", "↑ {{Heart}} +3 Health", "{{SoulHeart}} +3 Soul Hearts",
+	"↑ {{EmptyHeart}} +1 Empty heart container", "{{SoulHeart}} +1 Soul Heart", "↑ {{EmptyHeart}} +2 Empty heart containers", "{{SoulHeart}} +2 Soul Hearts",
+	"{{Heart}} Full health", "", "{{Heart}} Heals 1 heart", "", "{{HalfHeart}} Heals half a heart", "", "{{Heart}} Heals 2 hearts", ""}, -- Red HP to Soul Hearts, removes heals
+	
+	["Red to Black"] = {"↑ {{Heart}} +1 Health", "{{BlackHeart}} +1 Black Heart", "↑ {{Heart}} +2 Health", "{{BlackHeart}} +2 Black Hearts", "↑ {{Heart}} +3 Health", "{{BlackHeart}} +3 Black Hearts",
+	"↑ {{EmptyHeart}} +1 Empty heart container", "{{BlackHeart}} +1 Black Heart", "↑ {{EmptyHeart}} +2 Empty heart containers", "{{BlackHeart}} +2 Black Hearts",
+	"{{Heart}} Full health", "", "{{Heart}} Heals 1 heart", "", "{{HalfHeart}} Heals half a heart", "", "{{Heart}} Heals 2 hearts", ""}, -- Red HP to Black Hearts, removes heals
+	
+	["Red to Bone"] = {"↑ {{Heart}} +1 Health", "{{BoneHeart}} +1 Bone Heart", "↑ {{Heart}} +2 Health", "{{BoneHeart}} +2 Bone Hearts", "↑ {{Heart}} +3 Health", "{{BoneHeart}} +3 Bone Hearts",
+	"↑ {{EmptyHeart}} +1 Empty heart container", "{{EmptyBoneHeart}} +1 Empty Bone Heart", "↑ {{EmptyHeart}} +2 Empty heart containers", "{{EmptyBoneHeart}} +2 Empty Bone Hearts"}, -- Red HP to Bone Hearts
+	
+	["Red to Coin"] = {"{{Heart}} +","{{CoinHeart}} +", "{{EmptyHeart}} +","{{EmptyCoinHeart}} +",
+	"{{Heart}} Full health", "{{CoinHeart}} Full health", "{{Heart}} Heals 1 heart", "{{CoinHeart}} Heals 1 coin", "{{HalfHeart}} Heals half a heart", "{{CoinHeart}} Heals 1 coin", "{{Heart}} Heals 2 hearts", "{{CoinHeart}} Heals 2 coins"}, -- Red HP to Coin Hearts
+	
+	["Red to None"] = {"↑ {{Heart}} +1 Health", "", "↑ {{Heart}} +2 Health", "", "↑ {{Heart}} +3 Health", "",
+	"↑ {{EmptyHeart}} +1 Empty heart container", "", "↑ {{EmptyHeart}} +2 Empty heart containers", "",
+	"{{Heart}} Full health", "", "{{Heart}} Heals 1 heart", "", "{{HalfHeart}} Heals half a heart", "", "{{Heart}} Heals 2 hearts", ""}, -- Red HP to None (The Lost)
+	
+	["Super Bandage Soul"] = {"{{SoulHeart}} +3 Soul Hearts"}, -- for Soul Heart chars
+	["Super Bandage Black"] = {"{{SoulHeart}} +2 Soul Heart#{{BlackHeart}} +1 Black Heart"}, -- for Black Heart chars
+	["Black Lotus Soul"] = {"{{SoulHeart}} +2 Soul Hearts#{{BlackHeart}} +1 Black Heart"}, -- for Soul Heart chars
+	["Black Lotus Black"] = {"{{SoulHeart}} +1 Soul Heart#{{BlackHeart}} +2 Black Hearts"}, -- for Black Heart chars
+	
+	
 	["5.100.135 (PHD)"] = "Spawns 2-3 coins if you have {1}", -- IV Bag PHD
 	["Keeper 0-1"] = "Spawns 0-1 coin as {1}", -- IV Bag/Piggy Bank Keeper
 	["5.100.549"] = "{1} simply gets ↑ {{Tears}} +0.4 Tears on pickup", -- Brittle Bones (Keeper+Lost)

--- a/descriptions/rep/en_us.lua
+++ b/descriptions/rep/en_us.lua
@@ -1112,7 +1112,6 @@ EID.descriptions[languageCode].horsepills={
 }
 
 ---------- Character Info ----------
--- TODO: make these more consistent with other descs, add icons, and is there any traits of the characters missing?
 local repCharacterInfo = {
 	[4] = {"???", "Can't have Red Hearts#{{SoulHeart}} Health ups grant Soul Hearts#{{DevilRoom}} Devil deals that would cost 1 or 2 Red Hearts will cost 1 or 2 Soul Hearts instead#Destroying poop spawns 1 blue fly"},
 	[8] = {"Lazarus", "Once per floor, when you die:#Resurrect as Lazarus Risen#Lose 1 Red Heart container#↑ {{Damage}} 0.5 Damage up"},
@@ -1125,7 +1124,7 @@ local repCharacterInfo = {
 	
 	[21] = {"Tainted Isaac", "Item pedestals cycle between 2 options#You can only carry 8 passive items#Change which item will be dropped for a 9th item with {{ButtonRT}}"},
 	[22] = {"Tainted Magdalene", "Health above 2 Red Hearts will slowly drain#On contact, do a melee swing for 6x damage#{{HalfRedHeart}} Chance for enemies to drop Half Red Hearts that disappear in 2 seconds#Drop is guaranteed on melee kill#{{Collectible45}} Heal twice as much from non-pickup sources#{{AngelDevilChance}} Damage taken to draining hearts doesn't affect Devil Deal chance"},
-	[23] = {"Tainted Cain", "Touching an item pedestal turns it into a variety of pickups"}, --todo: merge better with base BoC desc
+	[23] = {"Tainted Cain", "Touching an item pedestal turns it into a variety of pickups"},
 	[24] = {"Tainted Judas", "Can't have Red Hearts#{{BlackHeart}} Health ups grant Black Hearts"},
 	[25] = {"Tainted ???", "Bombs are replaced with Poop Spells#{{Crafting29}} Doing damage spawns poop pickups#{{Collectible715}} You can store the next spell for later by using Hold"},
 	[26] = {"Tainted Eve", "Holding Fire converts your hearts into Clot familiars#Different Heart types spawn Clots with more health and tear effects#Clots lose health over time#Clots stay in place while holding {{ButtonRT}}#At half a heart left with no Clots, you gain a Mom's Knife-like attack until you heal and leave the room"},

--- a/descriptions/rep/en_us.lua
+++ b/descriptions/rep/en_us.lua
@@ -116,7 +116,7 @@ local repCollectibles={
 	[263] = {"263", "Clear Rune", "{{Rune}} Spawns 1 rune on pickup#{{Rune}} Triggers the effect of the rune Isaac holds without using it"}, -- Clear Rune (Repentance item)
 	[264] = {"264", "Smart Fly", "Orbital#Attacks enemies when Isaac takes damage#Deals 6.5 contact damage per second"}, -- Smart Fly
 	[272] = {"272", "BBF", "Friendly exploding fly#The explosion deals 100 damage#{{Warning}} The explosion can hurt Isaac"}, -- BBF
-	[273] = {"273", "Bob's Brain", "Dashes in the direction Isaac is shooting#Explodes when it hits an enemy#{{Poison}} The explosion deals 100 damage, ignores boss armor and poisons enemies#{{Warning}} The explosion can hurt Isaac"}, -- Bob's Brain
+	[273] = {"273", "Bob's Brain", "Dashes in the direction Isaac is shooting#Explodes when it hits an enemy#{{Poison}} The explosion deals 100 damage and poisons enemies#{{Warning}} The explosion can hurt Isaac"}, -- Bob's Brain
 	[274] = {"274", "Best Bud", "Taking damage spawns one midrange orbital for the room#It deals 150 contact damage per second"}, -- Best Bud
 	[275] = {"275", "Lil Brimstone", "{{Chargeable}} Familiar that charges and shoots a {{Collectible118}} blood beam#It deals 24 damage over 0.63 seconds"}, -- Lil Brimstone
 	[276] = {"276", "Isaac's Heart", "Isaac becomes invincible#Spawns a heart familiar that follows Isaac#The heart charges up when Isaac fires and releases a burst of tears when he stops#{{Warning}} If the heart familiar gets hit, Isaac takes damage"}, -- Isaac's Heart
@@ -1067,7 +1067,7 @@ EID.descriptions[languageCode].horsepills={
 	{"6", "Health Down", "↓ {{EmptyHeart}} -2 Health#Becomes a Health Up horse pill at 0 or 1 heart containers"}, -- Health Down
 	{"7", "Health Up", "↑ {{EmptyHeart}} +2 Empty heart containers"}, -- Health Up
 	{"8", "I Found Pills", "No effect"}, -- I Found Pills
-	{"9", "Puberty", "No effect"}, -- Puberty
+	{"9", "Puberty", "No effect#Eating 3 grants the Adult transformation:#↑ {{Heart}} +1 Health"}, -- Puberty
 	{"10", "Pretty Fly", "{{Collectible279}} Grants a Big Fan orbital#There is no limit on the number of Big Fans Isaac can have"}, -- Pretty Fly
 	{"11", "Range Down", "↓ {{Range}} -2 Range"}, -- Range Down
 	{"12", "Range Up", "↑ {{Range}} +2.5 Range"}, -- Range Up
@@ -1114,35 +1114,35 @@ EID.descriptions[languageCode].horsepills={
 ---------- Character Info ----------
 -- TODO: make these more consistent with other descs, add icons, and is there any traits of the characters missing?
 local repCharacterInfo = {
-	[4] = {"???", "Can't have Red Hearts#Devil deals that would cost 1 or 2 Red Hearts will cost 1 or 2 Soul Hearts instead#Destroying poop spawns 1 blue fly"},
+	[4] = {"???", "Can't have Red Hearts#{{SoulHeart}} Health ups grant Soul Hearts#{{DevilRoom}} Devil deals that would cost 1 or 2 Red Hearts will cost 1 or 2 Soul Hearts instead#Destroying poop spawns 1 blue fly"},
 	[8] = {"Lazarus", "Once per floor, when you die:#Resurrect as Lazarus Risen#Lose 1 Red Heart container#↑ {{Damage}} 0.5 Damage up"},
 	[11] = {"Lazarus Risen", "Increased stats and x1.4 damage multiplier#When entering a new floor, turn back into Lazarus"},
-	[12] = {"Dark Judas", "x2 Damage multiplier#Can't have Red Hearts#Health ups grant Black Hearts#Counts as Judas for completion marks"},
-	[14] = {"Keeper", "Heal by picking up coins#Heart pickups are turned into Blue Flies#Devil deals cost 15 or 30 coins"},
-	[18] = {"Bethany", "Use Soul Hearts to charge your active item#Can't use Soul Hearts as health"},
+	[12] = {"Dark Judas", "{{Damage}} x2 Damage multiplier#Can't have Red Hearts#{{BlackHeart}} Health ups grant Black Hearts#{{Player3}} Counts as Judas for completion marks"},
+	[14] = {"Keeper", "{{CoinHeart}} Heal by picking up coins#Maximum of 3 Coin Hearts#Heart pickups are turned into Blue Flies#{{DevilRoom}} Devil deals cost 15 or 30 coins"},
+	[18] = {"Bethany", "{{SoulHeart}} Use Soul Hearts to charge your active item#Can't use Soul Hearts as health"},
 	[19] = {"Jacob", "Control Jacob and Esau at the same time#Both characters drop a bomb when one is used#Esau stays in place while holding {{ButtonRT}}#{{ButtonLT}} uses Jacob's active, {{ButtonRB}} uses Esau's active, hold {{ButtonRT}} to use their card/pill#When there's a choice between items, Jacob and Esau can grab two simultaneously"},
 	[20] = {"Esau", "Control Jacob and Esau at the same time#Both characters drop a bomb when one is used#Esau stays in place while holding {{ButtonRT}}#{{ButtonLT}} uses Jacob's active, {{ButtonRB}} uses Esau's active, hold {{ButtonRT}} to use their card/pill#When there's a choice between items, Jacob and Esau can grab two simultaneously"},
 	
-	[21] = {"Tainted Isaac", "Item pedestals cycle between 2 options#You can only carry 8 passive items#Cycle which item will be dropped for a 9th item with {{ButtonRT}}"},
-	[22] = {"Tainted Magdalene", "Health above 2 Red Hearts will slowly drain#On contact, do a melee swing for 6x damage#Chance for enemies to drop Half Red Hearts that disappear in 2 seconds#Drop is guaranteed on melee kill#Heal twice as much from non-pickup sources#Damage taken to draining hearts doesn't affect Devil Deal chance"},
-	[23] = {"Tainted Cain", "Touching an item pedestal turns it into a variety of pickups#Gain items by crafting 8 pickups together in the Bag of Crafting#The Bag's contents can be shifted with {{ButtonRT}} to replace specific pickups when full"},
-	[24] = {"Tainted Judas", "Can't have Red Hearts#Health ups grant Black Hearts"},
-	[25] = {"Tainted ???", "Can't have Red Hearts#Bombs are replaced with Poop Spells#Doing damage spawns poop pickups#The HUD has a preview of your upcoming poop spells#You can store the next spell for later by using Hold"},
-	[26] = {"Tainted Eve", "Holding Fire converts your hearts into Clot familiars#Different Heart types spawn Clots with more health and tear effects#Clots lose health over time#Using Sumptorium will absorb the Clots back into your health, if possible#Clots stay in place while holding {{ButtonRT}}#At half a heart left with no Clots, you gain a Mom's Knife-like attack until you heal and leave the room"},
+	[21] = {"Tainted Isaac", "Item pedestals cycle between 2 options#You can only carry 8 passive items#Change which item will be dropped for a 9th item with {{ButtonRT}}"},
+	[22] = {"Tainted Magdalene", "Health above 2 Red Hearts will slowly drain#On contact, do a melee swing for 6x damage#{{HalfRedHeart}} Chance for enemies to drop Half Red Hearts that disappear in 2 seconds#Drop is guaranteed on melee kill#{{Collectible45}} Heal twice as much from non-pickup sources#{{AngelDevilChance}} Damage taken to draining hearts doesn't affect Devil Deal chance"},
+	[23] = {"Tainted Cain", "Touching an item pedestal turns it into a variety of pickups"}, --todo: merge better with base BoC desc
+	[24] = {"Tainted Judas", "Can't have Red Hearts#{{BlackHeart}} Health ups grant Black Hearts"},
+	[25] = {"Tainted ???", "Bombs are replaced with Poop Spells#{{Crafting29}} Doing damage spawns poop pickups#{{Collectible715}} You can store the next spell for later by using Hold"},
+	[26] = {"Tainted Eve", "Holding Fire converts your hearts into Clot familiars#Different Heart types spawn Clots with more health and tear effects#Clots lose health over time#Clots stay in place while holding {{ButtonRT}}#At half a heart left with no Clots, you gain a Mom's Knife-like attack until you heal and leave the room"},
 	[27] = {"Tainted Samson", "Dealing or taking damage builds up Berserk mode#{{Timer}} When you go berserk, receive for 5 seconds:#↑ {{Speed}} +0.4 Speed#↓ {{Tears}} x0.5 Fire rate multiplier#↑ {{Tears}} +2 Fire rate#↑ {{Damage}} +3 Damage#Restricts attacks to a melee that reflects shots#{{Timer}} Each kill increases the duration by 1 second and grants brief invincibility"},
 	[28] = {"Tainted Azazel", "When you start charging, you sneeze blood#Hitting an enemy with the sneeze halves your charge time#The sneeze deals 1.5x Azazel's damage#{{BrimstoneCurse}} Affected enemies take extra damage from Brimstone beams#On death, cursed enemies explode and pass on the curse to nearby enemies"},
-	[29] = {"Tainted Lazarus", "Lazarus has two states, each with their own items and health#Whenever you clear a room/wave or use Flip, you're switched to the other state"},
+	[29] = {"Tainted Lazarus", "Lazarus has two states, each with their own items and health#Clearing a room/wave or using Flip switches to the other state"},
 	[30] = {"Tainted Eden", "When you take damage, reroll your stats, items, trinket, and consumables#Items reroll into an item from the same item pool#Self-damage doesn't reroll"},
-	[31] = {"Tainted Lost", "Cards that spawn have a 10% chance to be Holy Card#Quality {{Quality2}} or less items have a 20% chance to be rerolled#Only \"offensive\" items can spawn"},
+	[31] = {"Tainted Lost", "{{Card51}} Cards that spawn have a 10% chance to be Holy Card#Quality {{Quality2}} or less items have a 20% chance to be rerolled#Only \"offensive\" items can spawn"},
 	[32] = {"Tainted Lilith", "Pressing Fire launches a short-range fetus melee attack that does 3x damage#Holding Fire keeps the fetus out shooting tears towards the nearest enemy"},
-	[33] = {"Tainted Keeper", "Enemies drop coins that disappear in 2 seconds#Most item pedestals cost 15 coins#Devil deals and Angel items cost 15 or 30 coins#Shops don't require a key and have increased stock"},
+	[33] = {"Tainted Keeper", "Maximum of 2 Coin Hearts#Enemies drop coins that disappear in 2 seconds#Most item pedestals cost 15 coins#Devil deals and Angel items cost 15 or 30 coins#Shops don't require a key and have increased stock"},
 	[34] = {"Tainted Apollyon", ""},
-	[35] = {"Tainted Forgotten", "The Forgotten is an immobile bone pile that is picked up and thrown by The Soul for 3x damage#Only The Soul can take damage#Bombs are placed at Forgotten's location#Can't have Red Hearts"},
-	[36] = {"Tainted Bethany", "Use Red Hearts to charge your active item#Can't have Red Hearts#Stat increases are only 75% effective"},
-	[37] = {"Tainted Jacob", "Dark Esau chases you, charging towards you when close#Anima Sola will chain Dark Esau down briefly, charging at you after 5 seconds or on using Anima Sola again#Dark Esau's charge does a lot of damage to enemies and ignores Boss Armor#If he hits you, you turn into a ghost that dies in one hit for the rest of the floor#While a ghost, one devil deal per room can be taken for free"},
-	[38] = {"Dead Tainted Lazarus", "Lazarus has two states, each with their own items and health#Whenever you clear a room/wave or use Flip, you're switched to the other state"},
+	[35] = {"Tainted Forgotten", "The Forgotten is an immobile bone pile that is picked up and thrown by The Soul for 3x damage#Only The Soul can take damage#Bombs are placed at Forgotten's location#Can't have Red Hearts#{{SoulHeart}} Health ups grant Soul Hearts"},
+	[36] = {"Tainted Bethany", "{{Heart}} Use Red Hearts to charge your active item#Can't have Red Hearts#{{SoulHeart}} Health ups grant Soul Hearts and blood charges#Stat increases are only 75% effective"},
+	[37] = {"Tainted Jacob", "Dark Esau chases you, charging towards you when close#The charge does a lot of damage to enemies#If he hits you, you turn into a ghost that dies in one hit for the rest of the floor#While a ghost, one devil deal per room can be taken for free"},
+	[38] = {"Dead Tainted Lazarus", "Lazarus has two states, each with their own items and health#Clearing a room/wave or using Flip switches to the other state"},
 	[39] = {"Tainted Jacob 2", ""},
-	[40] = {"Tainted Forgotten Soul", "The Forgotten is an immobile bone pile that is picked up and thrown by The Soul for 3x damage#Only The Soul can take damage#Bombs are placed at Forgotten's location#Can't have Red Hearts"},
+	[40] = {"Tainted Forgotten Soul", "The Forgotten is an immobile bone pile that is picked up and thrown by The Soul for 3x damage#Only The Soul can take damage#Bombs are placed at Forgotten's location#Can't have Red Hearts#{{SoulHeart}} Health ups grant Soul Hearts"},
 }
 EID:updateDescriptionsViaTable(repCharacterInfo, EID.descriptions[languageCode].CharacterInfo)
 
@@ -1347,12 +1347,7 @@ local repConditions = {
 	
 	
 	------ SPECIFIC CHARACTER SYNERGIES/CHANGES ------
-	["Red to Soul"] = {"{{Heart}} +","{{SoulHeart}} +", "{{Heart}} Full health", "", "{{Heart}} Heals 1 heart", ""}, -- Red HP to Soul Hearts, removes heals
-	["Red to Black"] = {"{{Heart}} +","{{BlackHeart}} +", "{{Heart}} Full health", "", "{{Heart}} Heals 1 heart", ""}, -- Red HP to Black Heart, removes heals
-	["Red to Coin"] = {"{{Heart}} +","{{CoinHeart}} +", "{{Heart}} Full health", "{{CoinHeart}} Full Health", "{{Heart}} Heals 1 heart", "{{CoinHeart}} Heals 1 coin"},
-
-
-	["5.100.642"] = "Single use for {1}", -- Magic Skin + Lost
+	["5.100.642"] = {"!!! SINGLE USE !!!#Spawns an item from the current room's item pool"}, -- Magic Skin + Lost
 	["5.100.240"] = "{1} keeps the stat changes when he drops it", -- Experimental Treatment + Tainted Isaac
 	["5.100.644"] = "{1} keeps the stat increase when he drops it", -- Consolation Prize + Tainted Isaac
 	["5.100.549"] = "{1} simply gets ↑ {{Tears}} +0.4 Fire rate on pickup", -- Brittle Bones (Keeper+Lost)
@@ -1368,13 +1363,21 @@ local repConditions = {
 	["5.100.230 (Bethany)"] = "{1} is left with half a heart", -- Abaddon
 	["5.100.230 (Tainted Bethany)"] = "{1} doesn't lose her blood charges", -- Abaddon
 	["5.100.245 (Keeper)"] = "Fire rate up and decreased tear spread for {1}", -- 20/20 + Keeper
-	["5.100.705"] = "Temporary +1 damage up for each bullet/enemy", -- Dark Arts + Dark/Tainted Judas
 	["5.100.205 (Tainted Magdalene)"] = "Allows infinite usage of Yum Heart", -- Sharp Plug + Tainted Magdalene
+	
+	["5.100.705"] = "Temporary +1 damage up for each bullet/enemy", -- Dark Arts + Dark/Tainted Judas
+	["5.100.722"] = {"Chains down Dark Esau#After 5 seconds or upon using Anima Sola again, he breaks free and dashes towards Jacob"}, -- TJacob + Anima Sola
+	["5.100.713"] = {"Recalls all clots to Eve's health bar#Excess clots are simply moved to her location#{{Timer}} 1 second recharge time"}, --Teve + Sumptorium
+	["5.100.711"] = {"Entering", "{{Player38}} Flips Lazarus to the other state#Entering"}, -- Tlaz + Flip
+	["5.100.710"] = {"Upon use, attacking swipes the bag in the chosen direction#Swiping at a pickup puts it in the bag#The Bag's contents can be shifted with {{ButtonRT}} to replace specific pickups when full#Holding the Use key when the bag is full crafts the previewed item#Item quality is based on the quality of the pickups"}, -- Tcain Bag of Crafting
+	
 	-- Vibrant/Dim Bulb
 	["5.350.100 (Bethany)"] = "Works with {1}'s soul charges",
 	["5.350.100 (Tainted Bethany)"] = "Works with {1}'s blood charges",
 	["5.350.101 (Bethany)"] = "Ignores {1}'s soul charges",
 	["5.350.101 (Tainted Bethany)"] = "Ignores {1}'s blood charges",
+	["Health Up Soul Charges"] = "+{1} soul charges",
+	["Health Up Blood Charges"] = "+{1} blood charges",
 	
 	
 	------ DUPLICATE COPIES OF ITEMS ------
@@ -1443,7 +1446,7 @@ local repConditions = {
 	
 	["White Poop Jar"] = "Spawns White Poop on 1 charge use",
 	["Golden Poop Jar"] = "Chance to spawn Golden Poop on 1 charge use",
-	
+		
 }
 EID:updateDescriptionsViaTable(repConditions, EID.descriptions[languageCode].ConditionalDescs)
 

--- a/descriptions/rep/en_us.lua
+++ b/descriptions/rep/en_us.lua
@@ -1434,8 +1434,8 @@ local repConditions = {
 	["Technology Ipecac"] = "The laser gets +2 damage and explodes on targets",
 	["Eye of the Occult Beam"] = "Isaac automatically shoots with a crosshair that alters the beam's path",
 	
-	["Lullaby Tainted Eve"] = "Clot fire rate is doubled",
-	["Lullaby Lilith"] = "Incubus fire rate is doubled",
+	["Lullaby Clots"] = "(Including clots)",
+	["Lullaby Incubus"] = "(Including Incubus)",
 	
 	-- Jacob's Ladder / 120 Volt battery synergies
 	["Sparks Damage"] = "Sparks deal 50% more damage",

--- a/descriptions/rep/ko_kr.lua
+++ b/descriptions/rep/ko_kr.lua
@@ -1432,8 +1432,8 @@ local repConditions={
 	["Technology Ipecac"] = "공격력 증가가 +2로 감소, 레이저에 가장 가까이 닿은 장애물이나 적의 위치에서 폭발합니다.",
 	["Eye of the Occult Beam"] = "조준점 + 자동 공격이 적용되며 {{ButtonRT}}버튼을 눌러 자동 공격을 멈출 수 있습니다.",
 
-	["Lullaby Tainted Eve"] = "클롯의 연사 x2",
-	["Lullaby Lilith"] = "Incubus의 연사 x2",
+	["Lullaby Clots"] = "클롯의 연사 x2",
+	["Lullaby Incubus"] = "Incubus의 연사 x2",
 
 	-- Jacob's Ladder / 120 Volt battery synergies
 	["Sparks Damage"] = "전류 피해량 +50%",

--- a/features/eid_api.lua
+++ b/features/eid_api.lua
@@ -2378,9 +2378,22 @@ end
 
 -- Replaces Variable placeholders in string with a given value
 -- Example: "My {1} message" --> "My test message"
+-- varID can be omitted to replace {1} (or pass in a string table, to replace {1}, {2}, etc.)
 function EID:ReplaceVariableStr(str, varID, newString)
+	if newString == nil then
+		newString = varID
+		varID = 1
+	end
 	if type(str) ~= "string" or newString == nil then return str end
-	return str:gsub("{"..varID.."}", newString)
+	
+	if type(newString) == "table" then
+		for i = 1, #newString do
+			str = str:gsub("{"..i.."}", newString[i])
+		end
+		return str
+	else
+		return str:gsub("{"..varID.."}", newString)
+	end
 end
 
 -- deep table copy, copied from http://lua-users.org/wiki/CopyTable
@@ -2404,4 +2417,11 @@ function EID:SimpleRound(num, dp)
 	dp = dp or 2
 	local mult = 10^dp
 	return math.floor(num * mult + 0.5)/mult
+end
+
+function EID:ArrayContains(t, value)
+	for _,v in ipairs(t) do
+		if v == value then return true end
+	end
+	return false
 end

--- a/features/eid_conditionals.lua
+++ b/features/eid_conditionals.lua
@@ -82,15 +82,29 @@ EID:AddConditional(297, function() return not EID:HaveNotUnlockedAchievement(366
 ------ NO RED HEALTH PLAYERS ------
 EID:AddConditional({442, "5.350.107", "5.350.119"}, EID.CheckForNoRedHealthPlayer, "No Red") -- Dark Prince's Crown, Crow Heart, Stem Cell
 EID:AddConditional(81, EID.CheckForNoRedHealthPlayer) -- Dead Cat
-EID:AddPlayerConditional({12, 15, 16, 22, 23, 24, 25, 26, 92, 101, 119, 121, 129, 138, 176, 182, 184, 189, 193, 218, 219, 226, 253, 307, 312, 314, 334, 342, 346, 354, 456}, 4, "Red to Soul") -- HP up to Soul heart for ???
-EID:AddPlayerConditional({12, 15, 16, 22, 23, 24, 25, 26, 92, 101, 119, 121, 129, 138, 176, 182, 184, 189, 193, 218, 219, 226, 253, 307, 312, 314, 334, 342, 346, 354, 456}, {14, 33}, "Red to Coin") -- HP up to Coin heart for Keepers
 if EID.isRepentance then
 	EID:AddConditional({569, 671, 676}, EID.CheckForNoRedHealthPlayer, "No Red") -- Blood Oath, Candy Heart, Empty Heart
 	EID:AddPlayerConditional({671, 676}, 14, "No Effect") -- Candy Heart / Empty Heart + Keeper
 	EID:AddPlayerConditional(676, 16, "No Effect", nil, false) -- Empty Heart + Forgotten (not Tainted)
-	EID:AddPlayerConditional({573, 591, 594, 614, 664, 669, 707, "5.350.156"}, 4, "Red to Soul") -- HP up to Soul heart for ???
-	EID:AddPlayerConditional({12, 15, 16, 22, 23, 24, 25, 26, 92, 101, 119, 121, 129, 138, 176, 182, 184, 189, 193, 218, 219, 226, 253, 307, 312, 314, 334, 342, 346, 354, 456, 573, 591, 594, 614, 664, 669, 707, "5.350.156"}, {12, 24}, "Red to Black") -- HP up to Black heart for Dark/Tainted Judas
-	EID:AddPlayerConditional({573, 591, 594, 614, 664, 669, 707, "5.350.156"}, {14, 33}, "Red to Coin") -- HP up to Coin heart for Keeper
+end
+
+for heartName, chars in pairs(EID.SpecialHeartPlayers) do
+	local c = {}
+	for charID,_ in pairs(chars) do table.insert(c, charID) end -- convert the lookup table into an array
+	for itemID, hearts in pairs(EID.HealthUpData) do
+		if itemID == 92 and (heartName == "Soul" or heartName == "Black") then
+			EID:AddClosestPlayerConditional(92, c, "Super Bandage " .. heartName, nil, false)
+		elseif itemID == 226 and (heartName == "Soul" or heartName == "Black") then
+			EID:AddClosestPlayerConditional(226, c, "Black Lotus " .. heartName, nil, false)
+		else
+			EID:AddClosestPlayerConditional(itemID, c, "Red to " .. heartName, nil, false)
+		end
+	end
+end
+if EID.isRepentance then
+	for itemID,charges in pairs(EID.BloodUpData) do
+		EID:AddPlayerConditional(itemID, 36, "Health Up Blood Charges", {variableText = charges})
+	end
 end
 
 
@@ -115,7 +129,8 @@ if EID.isRepentance then
 	EID:AddPlayerConditional(188, 2)                      -- Cain + Abel
 	EID:AddPlayerConditional({ 360, 728 }, 13)            -- Incubus/Gello + Lilith
 	EID:AddPlayerConditional({ 240, 644 }, 21)            -- Tainted Isaac + Experimental Treatment, Consolation Prize
-	EID:AddPlayerConditional({ 642, 694 }, 10)            -- Lost + Magic Skin, Heartbreak
+	EID:AddPlayerConditional(694, 10)                     -- Lost + Heartbreak
+	EID:AddClosestPlayerConditional(642, 10)              -- Lost + Magic Skin
 	EID:AddPlayerConditional(694, 14, "Keeper", nil, false) -- Keeper + Heartbreak
 	EID:AddPlayerConditional(694, 33, "Tainted Keeper")   -- Tainted Keeper + Heartbreak
 	EID:AddPlayerConditional("5.350.156", 14)             -- Keeper + Mother's Kiss
@@ -126,6 +141,11 @@ if EID.isRepentance then
 	EID:AddPlayerConditional(205, 22, "Tainted Magdalene")-- Tainted Magdalene + Sharp Plug
 	EID:AddPlayerConditional({"5.350.100", "5.350.101"}, 18, "Bethany", nil, false) -- Bethany + Vibrant/Dim Bulb
 	EID:AddPlayerConditional({"5.350.100", "5.350.101"}, 36, "Tainted Bethany") -- Tainted Bethany + Vibrant/Dim Bulb
+	
+	EID:AddPlayerConditional(722, 37) -- TJacob Anima Sola
+	EID:AddPlayerConditional(713, 26) -- TEve Sumptorium
+	EID:AddPlayerConditional(711, 29) -- TLaz Flip
+	EID:AddPlayerConditional(710, 23) -- Tcain Bag of Crafting
 end
 
 

--- a/features/eid_conditionals.lua
+++ b/features/eid_conditionals.lua
@@ -42,8 +42,8 @@ if EID.isRepentance then
 	
 	EID:AddSynergyConditional({584, 685, 702, 728}, "5.350.141", "No Effect From", "No Effect") -- Forgotten Lullaby no effect familiars (wisps, Gello)
 	EID:AddPlayerConditional("5.350.141", 32, "No Effect", {bulletpoint = "Collectible728", variableText = "{{NameOnlyC728}}"}) -- Forgotten Lullaby no effect on Tainted Lilith's Gello
-	EID:AddPlayerConditional("5.350.141", 13, "Lullaby Lilith", nil, false)
-	EID:AddPlayerConditional("5.350.141", 26, "Lullaby Tainted Eve")
+	EID:AddPlayerConditional("5.350.141", 13, "Lullaby Incubus", nil, false) -- Forgotten Lullaby effect for Incubus
+	EID:AddItemConditional("5.350.141", {713, "5.350.176"}, "Lullaby Clots") -- Forgotten Lullaby effect for clots
 end
 
 -- Abyss, Birthright Book of Belial, Binge Eater

--- a/features/eid_data.lua
+++ b/features/eid_data.lua
@@ -1015,10 +1015,22 @@ EID.TaintedIDs = {}; for i = 21, 40 do EID.TaintedIDs[i] = true end
 
 -- Character IDs that are Soul/Black Hearts only: ???, The Lost, The Soul
 EID.NoRedHeartsPlayerIDs = { [4] = true, [10] = true, [17] = true }
+-- More separated table for more exact data
+EID.SpecialHeartPlayers = {}
+EID.SpecialHeartPlayers["Soul"] = { [4] = true, [17] = true }
+EID.SpecialHeartPlayers["Black"] = {}
+EID.SpecialHeartPlayers["Coin"] = { [14] = true }
+EID.SpecialHeartPlayers["Bone"] = { [16] = true }
+EID.SpecialHeartPlayers["None"] = { [10] = true }
 if EID.isRepentance then
 	-- ???, The Lost, Black Judas, The Soul, Tainted Judas, Tainted ???, Tainted Lost, Tainted Forgotten, Tainted Bethany, Tainted Soul
 	EID.NoRedHeartsPlayerIDs = { [4] = true, [10] = true, [12] = true, [17] = true, [24] = true, [25] = true, [31] = true, [35] = true, [36] = true, [40] = true }
+	EID.SpecialHeartPlayers["Soul"] = { [4] = true, [17] = true, [25] = true, [35] = true, [36] = true, [40] = true }
+	EID.SpecialHeartPlayers["Black"] = { [12] = true, [24] = true }
+	EID.SpecialHeartPlayers["Coin"][33] = true
+	EID.SpecialHeartPlayers["None"][31] = true
 end
+
 -- Character IDs that have a pocket active (0 = normal, 1 = timed, 2 = special)
 EID.PocketActivePlayerIDs = { [22] = 0, [23] = 2, [24] = 1, [25] = 2, [26] = 1, [29] = 0, [34] = 0, [36] = 0, [37] = 1, [38] = 0, [39] = 1 }
 
@@ -1038,6 +1050,16 @@ EID.LuckFormulas["5.100.219"] = function(luck) return math.min(100 / (10 - math.
 if EID.isRepentance then
 	EID.LuckFormulas["5.100.219"] = function(luck) return (20 + luck) end -- Old Bandage: Base 20%, 100% at 80 Luck
 	EID.LuckFormulas["5.100.576"] = function(luck) return math.min(luck*0.5 + 6.25, 10) end -- Dirty Mind: Base 6.25%, 10% at 7.5 Luck
+end
+
+-- Number of Soul Hearts a character will get from a Health Up item
+-- (Pill ID is off by 1 because of EID one-indexed pill effects)
+EID.HealthUpData = {["5.70.8"] = 1, ["5.70.10"] = 1, [12] = 1, [15] = 1, [16] = 2, [22] = 1, [23] = 1, [24] = 1, [25] = 1, [26] = 1, [92] = 1, [101] = 1, [119] = 1, [121] = 1, [129] = 2, [138] = 1, [176] = 1, [182] = 1, [184] = 1, [189] = 1, [193] = 1, [218] = 1, [219] = 1, [226] = 1, [253] = 1, [307] = 1, [312] = 1, [314] = 1, [334] = 3, [342] = 1, [346] = 1, [354] = 1, [456] = 1 }
+if EID.isRepentance then
+	EID.HealthUpData["5.350.156"] = 1; EID.HealthUpData[573] = 1; EID.HealthUpData[591] = 1; EID.HealthUpData[594] = 2
+	EID.HealthUpData[614] = 1; EID.HealthUpData[664] = 1; EID.HealthUpData[669] = 1; EID.HealthUpData[707] = 1
+
+	EID.BloodUpData = {["5.70.10"] = 2, ["5.350.156"] = 2, ["5.300.12"] = 2, ["5.300.59"] = 4, [12] = 12, [15] = 12, [16] = 12, [22] = 4, [23] = 4, [24] = 4, [25] = 4, [26] = 4, [75] = 4, [92] = 4, [101] = 4, [119] = 10, [121] = 2, [129] = 4, [138] = 4, [176] = 4, [182] = 12, [184] = 4, [189] = 12, [193] = 4, [218] = 4, [226] = 4, [253] = 4, [307] = 4, [312] = 4, [314] = 4, [334] = 6, [342] = 4, [346] = 4, [354] = 4, [428] = 12, [456] = 4, [573] = 12, [591] = 4, [594] = 1, [614] = 10, [621] = 12, [664] = 12, [669] = 12, [707] = 4 }
 end
 
 

--- a/features/eid_modifiers.lua
+++ b/features/eid_modifiers.lua
@@ -250,7 +250,7 @@ local function BlackFeatherCallback(descObj)
 		description, _ =  EID:ReplaceVariableStr(description, 2, "{{"..dmgColor.."}}"..damageMultiplied.."{{CR}}")
 		if #EID.coopAllPlayers > 1 then description =  EID:GetPlayerIcon(playerType, "P" .. i .. ":") .. " " .. description end
 		
-		EID:appendToDescription(descObj, "# "..description)
+		EID:appendToDescription(descObj, "#"..description)
 	end
 	return descObj
 end


### PR DESCRIPTION
Multiple improvements to character info
Pocket item conditionals by biobak
New support for conditionals that only display when the character is the closest player; this will help single player display only relevant effects instead of having to append char-specific effects, while still being co-op friendly