### PR TITLE
Center the small bullet point icons

### DIFF
--- a/features/eid_api.lua
+++ b/features/eid_api.lua
@@ -917,7 +917,7 @@ function EID:filterIconMarkup(text, renderBulletPointIcon)
 		local preceedingTextWidth = EID:getStrWidth(string.sub(text, 0, textposition - 1)) * EID.Scale
 
 		-- Center the small bullet point icons by adding an extra left offset to them.
-		-- If the icon has an position left offset, that means the offset is already included in the icon itself and we should not add it again
+		-- If the icon has a positive left offset, that means the offset is already included in the icon itself and we should not add it again
 		if renderBulletPointIcon and lookup[3] < 11 and (#lookup < 5 or lookup[5] <= 0)  then
 			preceedingTextWidth  = preceedingTextWidth + math.floor((12 - lookup[3]) / 2) * EID.Scale
 		end

--- a/features/eid_api.lua
+++ b/features/eid_api.lua
@@ -916,7 +916,7 @@ function EID:filterIconMarkup(text, renderBulletPointIcon)
 		local lookup = EID:getIcon(word)
 		local preceedingTextWidth = EID:getStrWidth(string.sub(text, 0, textposition - 1)) * EID.Scale
 
-		-- Center the bullet point icons by adding an extra left offset to them.
+		-- Center the small bullet point icons by adding an extra left offset to them.
 		-- If the icon has an position left offset, that means the offset is already included in the icon itself and we should not add it again
 		if renderBulletPointIcon and lookup[3] < 11 and (#lookup < 5 or lookup[5] <= 0)  then
 			preceedingTextWidth  = preceedingTextWidth + math.floor((12 - lookup[3]) / 2) * EID.Scale

--- a/main.lua
+++ b/main.lua
@@ -728,7 +728,7 @@ function EID:printBulletPoints(description, renderPos)
 				local bpIcon, rejectedIcon = EID:handleBulletpointIcon(lineToPrint)
 				if EID:getIcon(bpIcon) ~= EID.InlineIcons["ERROR"] then
 					lineToPrint = string.gsub(lineToPrint, bpIcon .. " ", "", 1)
-					textColor =	EID:renderString(bpIcon, renderPos + Vector(-3 * EID.Scale, 0), textScale , textColor)
+					textColor =	EID:renderString(bpIcon, renderPos + Vector(-3 * EID.Scale, 0), textScale , textColor, true)
 				else
 					if rejectedIcon then lineToPrint = string.gsub(lineToPrint, rejectedIcon .. " ", "", 1) end
 					textColor =	EID:renderString(bpIcon, renderPos, textScale , textColor)


### PR DESCRIPTION
In EID, if the bullet point is an icon, the icon is left-aligned. This causes some odd behavior when displaying small icons like keys or coins in EID.

(In the image below, it is evident that the key icon is a bit too left.)
 
![image](https://github.com/user-attachments/assets/2a552c35-271a-4336-8c19-3e77e283fe97)

Especially when considering that the icons in the top-left corner of the game are center-aligned.

![image](https://github.com/user-attachments/assets/8c6d806a-9ca5-49f8-b8a9-19d0a0332eee)

This PR adds a corresponding left offset for bullet point icons with smaller widths and no built-in left offset (so {{ArrowUp}} and {{Heart}} are unaffected), making them appear center-aligned rather than left-aligned.

![image](https://github.com/user-attachments/assets/ab4abb73-ec46-4b9d-96d1-4b3ae93b67e6)
