### PR TITLE
add EID_EVALUATE_AUTO_LANG callback

### DIFF
--- a/features/eid_api.lua
+++ b/features/eid_api.lua
@@ -2324,7 +2324,18 @@ function EID:getLanguage()
 		lang = "auto"
 	end
 	if lang == "auto" then
-		return Options and EID.LanguageMap[Options.Language] or "en_us"
+		local langToReturn = Options and EID.LanguageMap[Options.Language] or "en_us"
+		-- don't do any updating if on a Repentance version before v1.7.9b
+		if Isaac.RunCallback ~= nil then
+			local newLang
+			for _, callbackData in pairs(Isaac.GetCallbacks("EID_EVALUATE_AUTO_LANG")) do
+				local newString = callbackData.Function(callbackData.Mod, langToReturn)
+				if newString and type(newString) == "string" and EID.descriptions[newString] ~= nil then
+					langToReturn = newString
+				end
+			end
+		end
+		return langToReturn
 	end
 	---@cast lang EID_LanguageCode
 	return lang


### PR DESCRIPTION
- this callback is for modders who make unofficial language patches, since rep+ does not have any language support except English
- only works on rep v1.7.9b or higher