### PR TITLE
Improve Sanguine Bond spike detection

### DIFF
--- a/features/eid_data.lua
+++ b/features/eid_data.lua
@@ -41,9 +41,8 @@ EID.GridEntityWhitelist = {
 				EID.Config["DisplaySacrificeInfo"]
 		end,
 		function(gridEntity)
-			return EID.isRepentance and EID.Config["DisplaySanguineInfo"] and
-				Game():GetRoom():GetType() == RoomType.ROOM_DEVIL and
-				EID:PlayersHaveCollectible(CollectibleType.COLLECTIBLE_SANGUINE_BOND)
+			return EID.isRepentance and gridEntity:GetVariant() >= 100 and
+				EID.Config["DisplaySanguineInfo"]
 		end,
 	},
 }

--- a/features/eid_itemprediction.lua
+++ b/features/eid_itemprediction.lua
@@ -113,13 +113,11 @@ end
 --order of checking: 15% Pennies, 48% Damage, 58% Hearts, 63% Item, 65% Leviathan, 100% Nothing
 local sanguineResults = { { 0.15, 3 }, { 0.48, 2 }, { 0.58, 4 }, { 0.63, 5 }, { 0.65, 6 }, { 1, 1 } }
 -- This function both trims the desc to just a list of chances, and highlights the next result if allowed, since those two actions are very intertwined
-function EID:trimSanguineDesc(descObj)
-	local currentRoom = game:GetLevel():GetCurrentRoom()
-	local spikes = currentRoom:GetGridEntity(67)
+function EID:trimSanguineDesc(spikes, descObj)
 	if not spikes then return "" end -- don't display anything if we can't find the spikes!
 	local cheatResult = nil
 	if spikes and EID.Config["PredictionSanguineBond"] then
-		local spikeSeed = currentRoom:GetGridEntity(67):GetRNG():GetSeed()
+		local spikeSeed = spikes:GetRNG():GetSeed()
 		spikeSeed = EID:RNGNext(spikeSeed, 5, 9, 7)
 		spikeSeed = EID:RNGNext(spikeSeed, 0x01, 0x05, 0x13) -- magic disassembled numbers!
 		local nextFloat = EID:SeedToFloat(spikeSeed)

--- a/main.lua
+++ b/main.lua
@@ -1616,16 +1616,15 @@ function EID:OnRender()
 				else -- Grid entities
 					local room = game:GetRoom()
 					if closest:GetType() == GridEntityType.GRID_SPIKES then
-						if room:GetType() == RoomType.ROOM_SACRIFICE and EID.Config["DisplaySacrificeInfo"] then
-							local desc = EID:getDescriptionObj(-999, -1, closest.VarData + 1, closest)
-							EID:addDescriptionToPrint(desc)
-						elseif EID.isRepentance and EID.Config["DisplaySanguineInfo"] and room:GetType() == RoomType.ROOM_DEVIL and
-							EID:PlayersHaveCollectible(CollectibleType.COLLECTIBLE_SANGUINE_BOND) then
+						if EID.isRepentance and closest:GetVariant() >= 100 and EID.Config["DisplaySanguineInfo"] then
 							local desc = EID:getDescriptionObj(5, 100, 692, closest, false)
-							desc.Description = EID:trimSanguineDesc(desc)
+							desc.Description = EID:trimSanguineDesc(closest, desc)
 							if desc.Description ~= "" then
 								EID:addDescriptionToPrint(desc)
 							end
+						elseif room:GetType() == RoomType.ROOM_SACRIFICE and EID.Config["DisplaySacrificeInfo"] then
+							local desc = EID:getDescriptionObj(-999, -1, closest.VarData + 1, closest)
+							EID:addDescriptionToPrint(desc)
 						end
 					end
 				end


### PR DESCRIPTION
We can just check the spike's variant and it'll always be a working sanguine bond spike. No need to assume room type and even if the player has the item.