### PR TITLE
ko_kr : 1.9.7.13 golden trinkets

### DIFF
--- a/descriptions/ab+/ko_kr.lua
+++ b/descriptions/ab+/ko_kr.lua
@@ -107,7 +107,7 @@ EID.descriptions[languageCode].collectibles={
 	{"44", "순간이동!", "사용 시 스테이지 안의 랜덤 방으로 순간이동합니다.#!!! 오류방으로는 이동하지 않습니다."}, -- Teleport!
 	{"45", "맛난 하트", "{{HealingRed}} 사용 시 체력 1칸을 회복합니다."}, -- Yum Heart
 	{"46", "행운의 발", "↑ {{LuckSmall}}행운 +1#↑ 방 클리어 보상이 등장할 확률이 대폭 증가합니다.#야바위와 도박기계의 성공 확률이 증가합니다."}, -- Lucky Foot
-	{"47", "박사의 원격 조종기", "{{Collectible168}} 사용 시 조준점을 이동시킨 곳으로 캐릭터의 공격력 x20의 미사일을 발사합니다."}, -- Doctor's Remote
+	{"47", "박사의 원격 조종기", "{{Collectible168}} 사용 시 조준점을 이동시킨 곳으로 공격력 x20의 미사일을 발사합니다."}, -- Doctor's Remote
 	{"48", "큐피드의 화살", "공격이 적을 관통합니다."}, -- Cupid's Arrow
 	{"49", "모두 다 사라져빔!!", "사용 시 공격방향으로 공격력 x2의 레이저포를 발사합니다."}, -- Shoop da Whoop!
 	{"50", "스티븐", "↑ {{DamageSmall}}공격력 +1"}, -- Steven
@@ -210,7 +210,7 @@ EID.descriptions[languageCode].collectibles={
 	{"147", "각진 곡괭이", "사용 시 그 방의 장애물을 부술 수 있습니다.#!!! 피격 시 해제됨"}, -- Notched Axe
 	{"148", "감염", "피격 시 파란 아군 파리를 1~3마리 소환합니다."}, -- Infestation
 	{"149", "구토제", "↑ {{DamageSmall}}공격력 +40#↓ {{TearsSmall}}공격 딜레이 x2.0 +10#폭발하는 독눈물을 곡선형으로 발사합니다."}, -- Ipecac
-	{"150", "사랑의 매", "10%의 확률로 캐릭터의 공격력 x3.2의 공격이 나갑니다.#{{LuckSmall}} 행운 9 이상일 때 100% 확률"}, -- Tough Love
+	{"150", "사랑의 매", "10%의 확률로 공격력 x3.2의 공격이 나갑니다.#{{LuckSmall}} 행운 9 이상일 때 100% 확률"}, -- Tough Love
 	{"151", "물리건", "적 명중 시 1/6 확률로 파란 아군 파리를 소환합니다."}, -- The Mulligan
 	{"152", "기계장치 2", "↓ {{TearsSmall}}공격 딜레이 x2.0#↓ {{DamageSmall}}공격력 배율 x0.65#오른쪽 눈에서 공격력 20%의 지속 레이저를 발사합니다."}, -- Technology 2
 	{"153", "돌연변이 거미", "↓ {{TearsSmall}}공격 딜레이 x2.1 +3#공격이 4발로 나갑니다."}, -- Mutant Spider
@@ -507,7 +507,7 @@ EID.descriptions[languageCode].collectibles={
 	{"444", "연필", "눈물을 15번 발사할 때마다 공격력 x2의 눈물 다발이 나갑니다."}, -- Lead Pencil
 	{"445", "개 이빨", "↑ {{DamageSmall}}공격력 +0.3#↑ {{SpeedSmall}}이동속도 +0.1#방에 {{SecretRoom}}{{SuperSecretRoom}}비밀방이나 {{LadderRoom}}사다리방이 연결되어 있을 경우 개 울음소리가 납니다."}, -- Dog Tooth
 	{"446", "죽은 이빨", "{{Poison}} 공격 시 캐릭터 주위에 적을 중독시키는 독가스가 나옵니다."}, -- Dead Tooth
-	{"447", "납작한 콩", "7.5초동안 공격을 멈추지 않고 공격을 유지할 시 그 방에서 15초동안 유지되는 갈색 구름이 생성되며;#구름에 닿은 적은 공격력 x5의 피해를 줍니다."}, -- Linger Bean
+	{"447", "납작한 콩", "7.5초동안 공격을 멈추지 않고 공격을 유지할 시 그 방에서 15초동안 유지되는 갈색 구름이 생성되며;#구름에 닿은 적은 캐릭터의 공격력 x5의 피해를 줍니다."}, -- Linger Bean
 	{"448", "유리 조각", "피격 시 25% 확률로 {{Heart}}빨간하트가 드랍되며;#10%의 확률로 그 방에서 캐릭터가 지나간 자리에 빨간 장판이 생깁니다.#장판은 지상의 적에게 초당 6의 피해를 줍니다."}, -- Shard of Glass
 	{"449", "강철판", "↑ {{SoulHeart}}소울하트 +1#적 탄환에 맞았을 때 25%의 확률로 유도 반사탄을 발사합니다."}, -- Metal Plate
 	{"450", "탐욕의 눈", "{{Petrify}} 눈물을 20번 발사할 때마다 {{ColorYellow}}동전을 1개 소모하고{{CR}} 캐릭터의 공격력 x2의 피해를 주며 적을 멈추게 만드는 눈물을 발사합니다.#멈춘 적 처치 시 {{Coin}}동전을 1~4개 드랍합니다."}, -- Eye of Greed
@@ -568,7 +568,7 @@ EID.descriptions[languageCode].collectibles={
 	{"505", "포켓 GO", "{{Friendly}} 방 입장 시 20%의 확률로 아래 중 하나의 아군 적을 소환합니다:#{{ArrowGrayRight}} Attack Fly#{{Blank}} Pooter#{{Blank}} One Tooth#{{Blank}} Fat Bat#{{Blank}} Frowning Gaper#{{Blank}} Vis"}, -- Poke Go
 	{"506", "배신자", "적을 뒤에서 공격할 시 2배의 피해를 입히고 {{BleedingOut}}출혈 상태로 만듭니다."}, -- BackStabber
 	{"507", "날카로운 빨대", "사용 시 그 방의 적에게 눈물 공격력 + 적 체력의 10%의 피해를 줍니다."}, -- Sharp Straw
-	{"508", "엄마의 면도칼", "{{BleedingOut}} 캐릭터 주위를 돌며 접촉하는 적에게 초당 공격력 x3의 피해를 출혈 피해를 줍니다."}, -- Mom's Razor
+	{"508", "엄마의 면도칼", "{{BleedingOut}} 캐릭터 주위를 돌며 접촉하는 적에게 초당 캐릭터의 공격력 x3의 피해를 출혈 피해를 줍니다."}, -- Mom's Razor
 	{"509", "피눈물 눈알", "캐릭터 주위를 돌며 자신이 바라보는 방향으로 공격력 3.5의 눈물을 발사합니다.#접촉하는 적에게 초당 30의 피해를 줍니다."}, -- Bloodshot Eye
 	{"510", "정신착란", "{{Timer}} 사용 시 그 방에서:#{{Friendly}} {{DeliriumSmall}} Delirium 버전의 아군 보스를 소환합니다."}, -- Delirious
 	{"511", "성난 파리", "적의 주위를 돌면서 접촉하는 적에게 초당 30의 피해를 줍니다."}, -- Angry Fly
@@ -685,7 +685,7 @@ EID.descriptions[languageCode].carBattery = {
 
 ---------- Trinkets ----------
 EID.descriptions[languageCode].trinkets={
-	{"1", "삼킨 동전", "{{Coin}} 피격 시 동전을 1~2개 드랍합니다."}, -- Swallowed Penny
+	{"1", "삼킨 동전", "{{Coin}} 피격 시 동전을 1개 드랍합니다."}, -- Swallowed Penny
 	{"2", "굳은 똥", "똥 파괴 시 픽업이 드랍될 확률이 50% 증가합니다."}, -- Petrified Poop
 	{"3", "AAA 건전지", "방 클리어 시 액티브 아이템의 충전량이 1칸 남았을 경우 액티브를 자동으로 충전합니다."}, -- AAA Battery
 	{"4", "고장난 조종기", "{{Collectible44}} 액티브 아이템 사용 시 스테이지 안의 랜덤 방으로 순간이동합니다."}, -- Broken Remote
@@ -713,7 +713,7 @@ EID.descriptions[languageCode].trinkets={
 	{"26", "꺾기벌레", "↑ {{RangeSmall}}사거리 +10#눈물이 지그재그로 날아갑니다."}, -- Hook Worm
 	{"27", "채찍벌레", "↑ {{ShotspeedSmall}}탄속 +0.5"}, -- Whip Worm
 	{"28", "부서진 앙크", "{{Player4}} 사망 시 22% 확률로 전 방에서 ??? 캐릭터로 부활합니다."}, -- Broken Ankh
-	{"29", "생선 머리", "피격 시 파란 아군 파리를 소환합니다."}, -- Fish Head
+	{"29", "생선 머리", "피격 시 파란 아군 파리를 하나 소환합니다."}, -- Fish Head
 	{"30", "분홍 눈알", "{{Poison}} 10%의 확률로 적을 중독시키는 공격이 나갑니다.#{{LuckSmall}} 행운 18 이상일 때 100% 확률"}, -- Pinky Eye
 	{"31", "고정핀", "10%의 확률로 적과 장애물을 관통하는 공격이 나갑니다.#{{LuckSmall}} 행운 18 이상일 때 100% 확률"}, -- Push Pin
 	{"32", "환각버섯", "방 입장 시 25% 확률로 그 방에서 랜덤 버섯 아이템 효과를 얻거나 맵에 특수방의 위치가 표시됩니다."}, -- Liberty Cap
@@ -775,7 +775,7 @@ EID.descriptions[languageCode].trinkets={
 	{"88", "필요없어!", "{{TreasureRoom}}보물방, {{Shop}}상점, {{DevilRoom}}악마방, {{AngelRoom}}천사방에서 99% 확률로 액티브 아이템이 나오지 않습니다."}, -- NO!
 	{"89", "미아 방지끈", "패밀리어들 사이의 간격이 가까워집니다."}, -- Child Leash
 	{"90", "갈색 마개", "!!! 똥 파괴시 똥이 폭발합니다."}, -- Brown Cap
-	{"91", "태변", "일반 똥이 확률적으로 검은 똥으로 대체됩니다.#{{BlackHeart}} 검은 똥 파괴시 확률적으로 블랙하트를 드랍합니다."}, -- Meconium
+	{"91", "태변", "일반 똥이 33%의 확률로 검은 똥으로 대체됩니다.#{{BlackHeart}} 검은 똥 파괴시 5%의 확률로 블랙하트를 드랍합니다."}, -- Meconium
 	{"92", "금이 간 왕관", "↑ {{TearsSmall}}연사 +0.2#각 능력치가 캐릭터 기본 능력치보다 높을 시 각 능력치가 33% 증가합니다."}, -- Cracked Crown
 	{"93", "다 쓴 기저귀", "방 입장 시 확률적으로 파리류 적들이 공격하지 않거나 약해집니다."}, -- Used Diaper
 	{"94", "생선 꼬리", "파란 아군 거미 또는 파리의 소환량이 2배로 증가합니다."}, -- Fish Tail
@@ -783,7 +783,7 @@ EID.descriptions[languageCode].trinkets={
 	{"96", "우주뱀 벌레", "↑ {{RangeSmall}}사거리 +4#↑ 눈물 높이 +2#눈물이 거대한 나선을 그리며 날아갑니다.#공격이 장애물을 관통합니다."}, -- Ouroboros Worm
 	{"97", "편도선", "{{Collectible474}} 12~20회 피격 시 Tonsil을 획득합니다.#{{Collectible474}} Tonsil은 캐릭터를 따라다니며 적의 탄환을 막아줍니다."}, -- Tonsil
 	{"98", "콧물딱지", "10%의 확률로 접착 눈물이 나가며 접착 눈물이 적에게 붙을 시 60초동안 지속 피해를 줍니다.#접착 눈물을 발사할 때 50%의 확률로 유도 효과가 생깁니다."}, -- Nose Goblin
-	{"99", "탱탱볼", "확률적으로 공격이 무언가에 부딪힐 때 반대 각도로 튕겨져 나갑니다."}, -- Super Ball
+	{"99", "탱탱볼", "10%의 확률로 공격이 무언가에 부딪힐 때 반대 각도로 튕겨져 나갑니다."}, -- Super Ball
 	{"100", "밝은 전구", "{{Battery}} 액티브 아이템의 충전량이 최대치일때:#{{ArrowGrayRight}} {{DamageSmall}}공격력 +0.5#{{ArrowGrayRight}} {{TearsSmall}}연사 +0.2#{{ArrowGrayRight}} {{RangeSmall}}사거리 +0.75#{{ArrowGrayRight}} {{SpeedSmall}}이동속도 +0.5#{{ArrowGrayRight}} {{ShotspeedSmall}}탄속 +0.1#{{ArrowGrayRight}} {{LuckSmall}}행운 +1"}, -- Vibrant Bulb
 	{"101", "꺼진 전구", "{{Battery}} 액티브 아이템의 충전량이 남아있지 않을때:#{{ArrowGrayRight}} {{DamageSmall}}공격력 +1.5#{{ArrowGrayRight}} {{TearsSmall}}연사 +0.4#{{ArrowGrayRight}} {{RangeSmall}}사거리 +1.5#{{ArrowGrayRight}} {{SpeedSmall}}이동속도 +0.5#{{ArrowGrayRight}} {{ShotspeedSmall}}탄속 +0.3#{{ArrowGrayRight}} {{LuckSmall}}행운 +2"}, -- Dim Bulb
 	{"102", "조각난 카드", "{{SecretRoom}} 스테이지 진입 시 비밀방이 하나 더 생성됩니다."}, -- Fragmented Card
@@ -792,17 +792,17 @@ EID.descriptions[languageCode].trinkets={
 	{"105", "점심 도시락", "!!! 일회용#피격 시 2% 확률로 {{Collectible22}}Lunch ({{Heart}}최대 체력 +1) 아이템을 생성합니다."}, -- Bag Lunch
 	{"106", "잃어버린 코르크", "캐릭터와 패밀리어가 생성하는 장판의 범위가 넓어집니다."}, -- Lost Cork
 	{"107", "까마귀 심장", "피격 시 빨간하트가 가장 우선적으로 소모됩니다.#!!! 악마방/천사방 확률을 방어해 주지 않습니다."}, -- Crow Heart
-	{"108", "호두", "!!! 일회용#캐릭터가 폭발에 휘말릴 경우 확률적으로 랜덤 픽업을 드랍합니다."}, -- Walnut
+	{"108", "호두", "!!! 일회용#캐릭터가 폭발에 휘말릴 경우 확률적으로 {{UnknownHeart}}하트, {{Coin}}동전, {{Key}}열쇠, {{Trinket}}장신구를 하나씩 드랍합니다."}, -- Walnut
 	{"109", "청테이프", "캐릭터의 위치를 기준으로 캐릭터를 따라오는 패밀리어의 위치를 고정시킵니다.#공전형 패밀리어가 회전하지 않습니다."}, -- Duct Tape
 	{"110", "은화", "{{Shop}} 7, 8 스테이지에서 상점이 생성됩니다."}, -- Silver Dollar
 	{"111", "피투성이 왕관", "{{TreasureRoom}} 7, 8 스테이지에서 보물방이 생성됩니다."}, -- Bloody Crown
 	{"112", "과금전사", "{{TreasureRoom}} 스테이지 진입 시 보물방에 재입고 기계가 생성됩니다."}, -- Pay To Win
-	{"113", "전쟁의 메뚜기", "{{Bomb}} 방 입장 시 적과 접촉 시 폭발하는 빨간 아군 파리를 소환합니다."}, -- Locust of War
-	{"114", "역병의 메뚜기", "{{Poison}} 방 입장 시 적을 중독시키는 초록 아군 파리를 소환합니다."}, -- Locust of Pestilence
-	{"115", "기근의 메뚜기", "{{Slow}} 방 입장 시 적을 느려지게 하는 노란 아군 파리를 소환합니다."}, -- Locust of Famine
-	{"116", "죽음의 메뚜기", "방 입장 시 공격력 4배의 피해를 주는 검은 아군 파리를 소환합니다."}, -- Locust of Death
-	{"117", "정복의 메뚜기", "방 입장 시 하얀 아군 파리를 2~5마리를 소환합니다."}, -- Locust of Conquest
-	{"118", "박쥐 날개", "적 처치 시 확률적으로 그 방에서 비행 능력을 얻습니다."}, -- Bat Wing
+	{"113", "전쟁의 메뚜기", "{{Bomb}} 방 입장 시 적과 접촉 시 폭발하는 빨간 아군 파리를 하나 소환합니다."}, -- Locust of War
+	{"114", "역병의 메뚜기", "{{Poison}} 방 입장 시 적을 중독시키는 초록 아군 파리를 하나 소환합니다."}, -- Locust of Pestilence
+	{"115", "기근의 메뚜기", "{{Slow}} 방 입장 시 적을 느려지게 하는 노란 아군 파리를 하나 소환합니다."}, -- Locust of Famine
+	{"116", "죽음의 메뚜기", "방 입장 시 공격력 4배의 피해를 주는 검은 아군 파리를 하나 소환합니다."}, -- Locust of Death
+	{"117", "정복의 메뚜기", "방 입장 시 하얀 아군 파리를 1~4마리 소환합니다."}, -- Locust of Conquest
+	{"118", "박쥐 날개", "적 처치 시 5%의 확률로 그 방에서 비행 능력을 얻습니다."}, -- Bat Wing
 	{"119", "줄기 세포", "{{HealingRed}} 스테이지 진입 시 체력을 반칸 회복합니다."}, -- Stem Cell
 	{"120", "머리핀", "{{Battery}} {{BossRoom}}보스방 최초 입장 시 액티브 아이템의 충전량을 모두 충전합니다."}, -- Hairpin
 	{"121", "나무 십자가", "{{HolyMantleSmall}} 스테이지 진입 시 피해 1번 무시하는 보호막을 생성합니다."}, -- Wooden Cross
@@ -810,7 +810,7 @@ EID.descriptions[languageCode].trinkets={
 	{"123", "세공 깃털", "{{AngelRoom}} Uriel/Gabriel이 Key Piece 대신 천사방 아이템을 드랍합니다.#!!! 한 종류의 Key Piece만 소지 시 Key Piece를 드랍합니다."}, -- Filigree Feather
 	{"124", "문 받침대", "방에 입장 시 들어왔던 문이 닫히지 않습니다."}, -- Door Stop
 	{"125", "연장 코드", "{{ColorCyan}}모든 캐릭터{{CR}}와 패밀리어 사이에 전류 레이저가 흐르며;#{{ArrowGrayRight}} 레이저에 접촉한 적은 초당 6의 피해를 받습니다."}, -- Extension Cord
-	{"126", "썩은 동전", "동전 획득 시 파란 아군 파리를 소환합니다."}, -- Rotten Penny
+	{"126", "썩은 동전", "동전 획득 시 파란 아군 파리를 하나 소환합니다."}, -- Rotten Penny
 	{"127", "아기 초능력자", "패밀리어의 공격에 유도 효과가 생깁니다."}, -- Baby-Bender
 	{"128", "손가락 뼈", "{{EmptyBoneHeart}} 피격 시 2% 확률로 뼈하트를 획득합니다."}, -- Finger Bone
 }

--- a/descriptions/rep+/ko_kr.lua
+++ b/descriptions/rep+/ko_kr.lua
@@ -82,9 +82,9 @@ EID:updateDescriptionsViaTable(collectibles, EID.descriptions[languageCode].coll
 
 local trinkets = {
 	-- Change: Added champion loot information
-	[5] = {"5", "퍼플 하트 훈장", "!!! 적이 챔피언의 형태로 나올 확률이 2배로 증가합니다.#가능한 경우, 보스가 챔피언의 형태로 나올 확률이 증가합니다.#챔피언 몬스터 처치 시 보상 드랍 확률 +20%p#챔피언 몬스터 보상이 2배로 등장합니다."}, -- Purple Heart
+	[5] = {"5", "퍼플 하트 훈장", "!!! 적이 챔피언의 형태로 나올 확률이 2배로 증가합니다.#가능한 경우, 보스가 챔피언의 형태로 나올 확률이 증가합니다.#챔피언 몬스터 처치 시 보상 드랍 확률 +50%#챔피언 몬스터 보상이 2배로 등장합니다."}, -- Purple Heart
 	-- Change: Added info about devil deals
-	[7] = {"7", "묵주 구슬", "{{AngelChanceSmall}} {{ColorOrange}}보스방 클리어로 악마방으로 향하는 문 등장 시{{CR}} 천사방으로 향하는 문으로 바뀝니다.#!!! {{Library}}책방과 {{Shop}}상점에서 {{Collectible33}}The Bible이 등장할 확률이 증가합니다."}, -- Rosary Bead
+	[7] = {"7", "묵주 구슬", "{{AngelChanceSmall}} {{ColorOrange}}보스방 클리어로 악마방으로 향하는 문 등장 시{{CR}} 천사방으로 향하는 문으로 바뀝니다.#↑ {{AngelChanceSmall}}천사방 확률 +50%#!!! {{Library}}책방과 {{Shop}}상점에서 {{Collectible33}}The Bible이 등장할 확률이 증가합니다."}, -- Rosary Bead
 	-- Change: added info about dropping the item
 	[16] = {"16", "엄마의 발톱", "클리어하지 않은 방에서 장신구를 버리면;#{{ArrowGrayRight}} {{MomBossSmall}} 그 위치에 엄마발이 떨어집니다."}, -- Mom's Toenail
 	-- Change: added Super Secret Room info
@@ -94,7 +94,7 @@ local trinkets = {
 	-- Change: added +0.5 damage
 	[66] = {"66", "게으른 벌레", "↑ {{DamageSmall}}공격력 +0.5#↓ {{ShotspeedSmall}}탄속 -0.5"}, -- Lazy Worm
 	-- Change: Complete rewrite
-	[70] = {"70", "머릿니", "방 클리어 시 파란 아군 거미를 하나 소환합니다."}, -- Louse
+	[70] = {"70", "머릿니", "클리어하지 않은 방에서 30초마다 파란 아군 거미를 하나 소환합니다.#방 클리어 시 파란 아군 거미를 하나 소환합니다."}, -- Louse
 	-- Change: Added more loot information
 	[76] = {"76", "포커 칩", "{{Chest}} 상자에서 50% 확률로 픽업이 추가로 드랍되거나 Attack Fly가 나옵니다.#상자에서 아이템이 나올 때 {{Quality3}}등급 + 랜덤 배열의 아이템이 나옵니다.#슬롯머신의 성공 확률 및 보상 빈도가 증가합니다."}, -- Poker Chip
 	-- Change: Added additional effects
@@ -104,8 +104,8 @@ local trinkets = {
 	-- Change: 33% chance, Spawns blue fly on new room
 	[93] = {"93", "다 쓴 기저귀", "방 입장 시 33%의 확률로 파리류 적들이 공격하지 않거나 약해집니다.#방 클리어 시 파란 아군 파리를 하나 소환합니다."}, -- Used Diaper
 	-- Change: Changed "12-20 times" to "6-12 times"
-	[97] = {"97", "편도선", "6~12 피격 시 Tonsil을 획득합니다.#Tonsil은 캐릭터를 따라다니며 적의 탄환을 막아줍니다."}, -- Tonsil
-	[99] = {"99", "탱탱볼", "확률적으로 공격이 무언가에 부딪힐 때 반대 각도로 튕겨져 나갑니다.#{{LuckSmall}} 행운 18 이상일 때 100% 확률"}, -- Super Ball
+	[97] = {"97", "편도선", "6~12 피격 시 Tonsil을 획득합니다.#Tonsil은 캐릭터를 따라다니며 적의 탄환을 막아줍니다.#!!! 2회 소환 시 사라집니다."}, -- Tonsil
+	[99] = {"99", "탱탱볼", "10%의 확률로 공격이 무언가에 부딪힐 때 반대 각도로 튕겨져 나갑니다.#{{LuckSmall}} 행운 18 이상일 때 100% 확률"}, -- Super Ball
 	-- Change: Added +2 Tears
 	[103] = {"103", "똑같다!", "!!! 소지중인 동전, 폭탄, 열쇠의 개수가 모두 같을 때:#{{ArrowGrayRight}} {{TearsSmall}} 연사(+상한) +2#{{ArrowGrayRight}} {{Heart}}하트, {{Coin}}동전, {{Bomb}}폭탄, {{Key}}열쇠 픽업이 1+1로 나옵니다."},
 	[104] = {"104", "창사골", "!!! 일회용#피격 시 5% 확률로 그 방의 아이템을 하나 생성합니다."}, -- Wish Bone
@@ -123,20 +123,326 @@ EID:updateDescriptionsViaTable(trinkets, EID.descriptions[languageCode].trinkets
 
 ------- Golden Trinkets -------
 local goldenTrinketData = {
-	[85] = {fullReplace = nil, findReplace = true, mult = 3},
+	[5] = {findReplace = true}, -- Purple Heart
+	[14] = {append = true}, -- Callus
+	[16] = {findReplace = true}, -- Mom's Toenail
+	[19] = {findReplace = true}, -- Paper Clip
+	[21] = {findReplace = true}, -- Mysterious Paper
+	[22] = {append = true}, -- Daemon's Tail
+	[28] = {findReplace = true}, -- Broken Ankh
+	[33] = {findReplace = true}, -- Umbilical Cord
+	[34] = {findReplace = true}, -- Child's Heart
+	[36] = {findReplace = true}, -- Rusted Key
+	[41] = {findReplace = true}, -- Match Stick
+	[43] = {fullReplace = true}, -- Cursed Skull
+	[44] = {findReplace = true}, -- Safety Cap
+	[45] = {findReplace = true}, -- Ace of Spades
+	[52] = {findReplace = true}, -- Counterfeit Penny
+	[54] = {findReplace = true}, -- Isaac's Head
+	[56] = {fullReplace = true}, -- Judas' Tongue
+	[57] = {findReplace = true}, -- ???'s Soul
+	[58] = {findReplace = true}, -- Samson's Lock
+	[61] = {append = true}, -- The Left Hand
+	[62] = {fullReplace = true}, -- Shiny Rock
+	[63] = {append = true}, -- Safety Scissors
+	[68] = {findReplace = true}, -- Super Magnet
+	[70] = {findReplace = true}, -- Louse
+	[71] = {append = true}, -- Bob's Bladder
+	[76] = {append = true}, -- Poker Chip
+	[83] = {append = true}, -- Store Key
+	[84] = {append = true}, -- Rib of Greed
+	[85] = {findReplace = true}, -- Karma
+	[87] = {findReplace = true}, -- Mom's Locket
+	[91] = {findReplace = true}, -- Meconium
+	[93] = {findReplace = true}, -- Used Diaper
+	[94] = {append = true}, -- Fish Tail
+	[97] = {findReplace = true}, -- Tonsil
+	[98] = {fullReplace = true}, -- Nose Goblin
+	[102] = {append = true}, -- Fragmented Card
+	[106] = {findReplace = true}, -- Lost Cork
+	[107] = {append = true}, -- Crow Heart
+	[108] = {findReplace = true}, -- Wallnut
+	[109] = {append = true}, -- Duct Tape
+	[110] = {findReplace = true}, -- Silver Dollar
+	[111] = {append = true}, -- Bloody Crown
+	[112] = {append = true}, -- Pay To Win
+	[113] = {findReplace = true}, -- Locust of War
+	[114] = {findReplace = true}, -- Locust of Pestilence
+	[115] = {findReplace = true}, -- Locust of Famine
+	[116] = {findReplace = true}, -- Locust of Death
+	[117] = {findReplace = true}, -- Locust of Conquest
+	[119] = {findReplace = true}, -- Stem Cell
+	[120] = {findReplace = true}, -- Hairpin
+	[121] = {findReplace = true}, -- Wooden Cross
+	[123] = {append = true}, -- Filigree Feather
+	[124] = {append = true}, -- Door Stop
+	[126] = {findReplace = true}, -- Rotten Penny
+	[127] = {append = true}, -- Baby-Bender
+	[131] = {findReplace = true}, -- Blessed Penny
+	[133] = {findReplace = true}, -- Short Fuse
+	[134] = {append = true}, -- Gigante Bean
+	[136] = {findReplace = true}, -- Broken Padlock
+	[138] = {findReplace = true}, -- 'M
+	[140] = {findReplace = true}, -- Apple of Sodom
+	[144] = {append = true}, -- Brain Worm
+	[146] = {append = true}, -- Devil’s Crown
+	[147] = {findReplace = true}, -- Charged Penny
+	[148] = {append = true}, -- Friendship Necklace
+	[149] = {append = true}, -- Panic Button
+	[150] = {append = true}, -- Blue Key
+	[151] = {append = true}, -- Flat File
+	[152] = {fullReplace = true}, -- Telescope Lens
+	[155] = {append = true}, -- Holy Crown
+	[157] = {findReplace = true}, -- Torn Card
+	[159] = {fullReplace = true}, -- Gilded Key
+	[161] = {append = true}, -- Wicked Crown
+	[165] = {append = true}, -- Nuh Uh!
+	[171] = {fullReplace = true}, -- Keeper’s Bargain
+	[172] = {append = true}, -- Cursed Penny
+	[173] = {append = true}, -- Your Soul
+	[175] = {fullReplace = true}, -- Strange Key
+	[177] = {append = true}, -- Temporary Tattoo
+	[179] = {append = true}, -- RC Remote
+	[180] = {t={0.5}, mults={1.5,2}}, -- Found Soul
+	[181] = {fullReplace = true}, -- Expansion Pack
+	[182] = {append = true}, -- Beth’s Essence
+	[184] = {append = true}, -- Adoption Papers
+	[189] = {findReplace = true}, -- Sigil of Baphomet
 }
 EID:updateDescriptionsViaTable(goldenTrinketData, EID.descriptions[languageCode].goldenTrinketData)
 
 local goldenTrinketEffects = {
+	-- Purple Heart (find replace):
+	[5] = { 2, 3, 4,  50, 66, 75 },
 	--[7] = { "{{AngelChanceSmall}} 천사방 확률 추가 증가" },
-	--[14] = {"희생방 가시의 피해가 절반으로 감소합니다.", "모든 피해가 절반으로 감소합니다."},
+	-- Callus (append):
+	[14] = {"{{SacrificeRoom}} 희생방 가시의 피해가 절반으로 감소합니다.", "{{Collectible108}} 대부분의 피해가 절반으로 감소합니다."},
+	-- Mom's Toenail (find replace):
+	[16] = {"엄마발이", "{{CR}}엄마발이 {{ColorGold}}2번", "{{CR}}엄마발이 {{ColorGold}}3번"},
+	-- Paper Clip (find replace):
+	[19] = {"열쇠가 필요한 모든 상자", "{{CR}}열쇠가 필요한 모든 상자 {{ColorGold}}및 열쇠 블록", "{{CR}}열쇠가 필요한 모든 상자, {{ColorGold}}열쇠 블록, 열쇠로 잠긴 문"},
+	-- Mysterious Paper (find replace):
+	[21] = {"하나", "2종류", "2종류"},
+	-- Daemon's Tail (append):
+	[22] = {"{{BlackHeart}} 파란색, 보라색 모닥불에서 소울하트 대신 블랙하트를 드랍합니다."},
+	-- Broken Ankh (find replace):
+	[28] = { 22, 33, 50 },
+	-- Umbilical Cord (find replace):
+	[33] = {"반칸", "한칸", "1.5칸"},
+	-- Child's Heart (find replace):
+	[34] = { 10, 20, 50,  33, 66, 100 },
+	-- Rusted Key (find replace):
+	[36] = { 10, 20, 50,  33, 66, 100 },
+	-- Match Stick (find replace):
+	[41] = { 10, 20, 50,  33, 66, 100 },
+	-- Cursed Skull (replace):
+	[43] = {
+		"{{HalfHeart}} 피격 시 빨간하트가 반칸 이하일 때 스테이지 안의 랜덤 {{ColorGold}}특수방{{CR}}으로 순간이동합니다.",
+		"{{Heart}} 피격 시 빨간하트가 {{ColorGold}}한칸{{CR}} 이하일 때 스테이지 안의 랜덤 {{ColorGold}}특수방{{CR}}으로 순간이동합니다.",
+	},
+	-- Safety Cap (find replace):
+	[44] = { 10, 20, 50,  33, 66, 100 },
+	-- Ace of Spades (find replace):
+	[45] = { 10, 20, 50,  33, 66, 100 },
+	-- Isaac's Fork (find replace):
+	[46] = {"반칸", "한칸", "1.5칸"},
+	-- Counterfeit Penny (find replace):
+	[52] = {"하나", "{{ColorGold}}2개{{CR}}", "{{ColorGold}}3{{CR}}개"},
 	-- Tick (replace): added ", {{Trinket135}} A Lighter"
 	[53] = {
 		"방 입장 시 체력이 60 이상인 적의 체력을 {{ColorGold}}30%{{CR}} 깎습니다.#{{HealingRed}} {{BossRoom}}보스방 입장 시 체력을 {{ColorGold}}두칸{{CR}} 회복합니다.",
 		"!!! {{Trinket41}}/{{Trinket135}}/{{Collectible479}}를 제외한 {{ColorOrange}}교체 및 버리기 불가{{CR}}#방 입장 시 체력이 60 이상인 적의 체력을 {{ColorGold}}30%{{CR}} 깎습니다.#{{HealingRed}} {{BossRoom}}보스방 입장 시 체력을 {{ColorGold}}두칸{{CR}} 회복합니다.",
 		"방 입장 시 체력이 60 이상인 적의 체력을 {{ColorGold}}30%{{CR}} 깎습니다.#{{HealingRed}} {{BossRoom}}보스방 입장 시 체력을 {{ColorGold}}세칸{{CR}} 회복합니다.",
 	},
+	-- Isaac's Head (find replace):
+	[54] = {"공격력 3.5", "캐릭터의 공격력 x1", "캐릭터의 공격력 x1.5"},
+	-- Judas' Tongue (replace):
+	[56] = {
+		"{{DevilRoom}} 악마방 상품 가격이 체력 2칸인 경우 체력 1칸으로 변경됩니다.#{{DevilRoom}} {{ColorGold}}악마방 상품 가격에 소울하트가 있는 경우 소울하트 가격을 1개 차감합니다.",
+		"{{DevilRoom}} 악마방 상품 가격이 체력 2칸인 경우 체력 1칸으로 변경됩니다.#{{DevilRoom}} {{ColorGold}}악마방 상품 가격에 소울하트가 있는 경우 소울하트 가격을 1개 차감합니다.#{{DevilRoom}} {{ColorGold}}악마방 상품 가격이 가시인 경우 1회 시도만에 반드시 아이템이 구매됩니다."
+	},
+	-- ???'s Soul (find replace):
+	[57] = {"방을 대각선으로 돌아다닙니다.", "{{CR}}방을 대각선으로 돌아다니는 패밀리어 {{ColorGold}}2명{{CR}}을 소환합니다.", "{{CR}}방을 대각선으로 돌아다니는 패밀리어 {{ColorGold}}3명{{CR}}을 소환합니다."},
+	-- Samson's Lock (find replace):
+	[58] = { 6.66, 13, 25 },
+	-- The Left Hand (append):
+	[61] = {
+		"{{RedChest}} 빨간상자가 보상을 추가로 드랍합니다.",
+		"{{RedChest}} 빨간상자가 보상을 추가로 드랍합니다.#{{RedChest}} {{ColorGold}}빨간상자에서 더 이상 적 거미가 등장하지 않습니다.",
+	},
+	-- Shiny Rock (replace):
+	[62] = {
+		"10초마다 색돌이나 {{LadderRoom}}사다리방이 있는 돌과 {{ColorGold}}{{SecretRoom}}{{SuperSecretRoom}}비밀방 입구{{CR}}가 빛납니다.",
+		"{{ColorGold}}5{{CR}}초마다 색돌이나 {{LadderRoom}}사다리방이 있는 돌과 {{ColorGold}}{{SecretRoom}}{{SuperSecretRoom}}비밀방 입구{{CR}}가 빛납니다.",
+	},
+	-- Safety Scissors (append):
+	[63] = {
+		"적 폭발의 범위가 줄어듭니다.",
+		"적 폭발의 범위가 대폭 줄어듭니다.",
+	},
+	-- Super Magnet (find replace):
+	[68] = {"적과 픽업이", "{{CR}}적과 픽업, {{ColorGold}}장신구, 자루{{CR}}가", "{{CR}}적과 픽업, {{ColorGold}}장신구, 자루, 상자{{CR}}가"},
+	-- Louse (find replace):
+	[70] = {"하나", "2마리", "3마리"},
+	-- Bob's Bladder (appendix):
+	[71] = {"독 장판의 크기가 증가합니다.", "독 장판의 크기와 지속시간이 증가합니다."},
+	-- Poker Chip (append):
+	[76] = {"{{Slotmachine}} 슬롯/거지류 보상 2배", "{{Slotmachine}} 슬롯/거지류 보상 3배"},
+	-- Store Key (append):
+	[83] = {"{{Shop}} 레벨이 매우 낮은 상점이 등장하지 않습니다.", "{{Shop}} 상점 레벨이 항상 최대치로 고정됩니다."},
+	-- Rib of Greed (append):
+	[84] = {"{{Coin}} 특수 동전 (1+1, 니켈, 다임, 행운, 황금)이 나올 확률이 증가합니다."},
+	-- Karma (find replace):
 	[85] = { "행운 %+1", "행운 +2", "행운 +3" },
+	-- Mom's Locket (find replace):
+	[87] = {"반칸", "한칸", "1.5칸"},
+	-- Meconium (find replace):
+	[91] = { 33, 66, 100,  5, 7, 10 },
+	-- Used Diaper (find replace):
+	[93] = {"하나", "2마리", "3마리"},
+	-- Fish Tail (append):
+	[94] = {"20%의 확률로 3배 소환", "20%의 확률로 4배 소환"},
+	-- Tonsil (find replace):
+	[97] = {"2회", "3회", "4회"},
+	-- Nose Goblin (replace):
+	[98] = {
+		"{{ColorGold}}20{{CR}}%의 확률로 접착 눈물이 나갑니다.#접착 눈물을 발사할 때 {{ColorGold}}75{{CR}}%의 확률로 유도 효과가 생깁니다.#{{DamageSmall}} 접착 눈물이 적에게 붙을 시 10초동안 지속 피해를 줍니다.",
+		"{{ColorGold}}30{{CR}}%의 확률로 접착 눈물이 나갑니다.#접착 눈물을 발사할 때 {{ColorGold}}100{{CR}}%의 확률로 유도 효과가 생깁니다.#{{DamageSmall}} 접착 눈물이 적에게 붙을 시 10초동안 지속 피해를 줍니다.",
+	},
+	-- Fragmented Card (append):
+	[102] = {"{{SecretRoom}} 맵에 랜덤 비밀방 하나의 위치를 표시합니다.", "{{SecretRoom}} 맵에 랜덤 비밀방 2개의 위치를 표시합니다."},
+	-- Lost Cork
+	[106] = {"넓어집니다", "대폭{{CR}} 넓어집니다"},
+	-- Crow Heart (append):
+	[107] = {
+		"{{AngelDevilChance}} 빨간하트 피격 시 25%의 확률로 악마방 확률 감소를 방어해 줍니다.",
+		"{{AngelDevilChance}} 빨간하트 피격 시 50%의 확률로 악마방 확률 감소를 방어해 줍니다.",
+	},
+	-- Walnut (find replace):
+	[108] = {
+		"하나씩",
+		"2개씩",
+		"3개씩",
+	},
+	-- Duct Tape (append):
+	[109] = {"{{ButtonRT}} (Ctrl)로 패밀리어의 진영을 바꿀 수 있습니다."},
+	-- Silver Dollar (find replace):
+	[110] = {"상점", "최대 레벨 상점"},
+	-- Bloody Crown (append):
+	[111] = {"보물방에 아이템이 하나 더 나오며 하나를 선택하면 나머지는 사라집니다."},
+	-- Pay To Win (append):
+	[112] = {"{{RestockMachine}} 재입고 기계의 터질 확률이 감소됩니다."},
+	-- Locust of War (find replace):
+	[113] = {"하나", "2마리", "3마리"},
+	-- Locust of Pestilence (find replace):
+	[114] = {"하나", "2마리", "3마리"},
+	-- Locust of Famine (find replace):
+	[115] = {"하나", "2마리", "3마리"},
+	-- Locust of Death (find replace):
+	[116] = {"하나", "2마리", "3마리"},
+	-- Locust of Conquest (find replace):
+	[117] = {"1~4마리", "2~5마리", "3~7마리"},
+	-- Stem Cell (find replace):
+	[119] = {"최대 체력의 절반을 회복합니다.", "체력을 전부 회복합니다."},
+	-- Hairpin (find replace):
+	[120] = {"모두", "초과하여"},
+	-- Wooden Cross (find replace):
+	[121] = {"1번", "2번"},
+	-- Filigree Feather (append):
+	[123] = {"{{HalfSoulHeart}} Uriel/Gabriel 처치 시 소울하트 반칸을 추가로 드랍합니다.", "{{SoulHeart}} Uriel/Gabriel 처치 시 소울하트 한칸을 추가로 드랍합니다."},
+	-- Door Stop (append):
+	[124] = {"보스러시를 시작해도 문이 닫히지 않습니다.", "도전방 및 보스러시를 시작해도 문이 닫히지 않습니다."},
+	-- Rotten Penny (find replace):
+	[126] = {"하나", "2마리", "3마리"},
+	-- Baby-Bender (append):
+	[127] = {"{{Trinket144}} 패밀리어 눈물의 유도 성능이 강화됩니다.", "{{Trinket144}} 패밀리어 눈물의 유도 성능이 강화됩니다.#{{Trinket65}} {{ColorGold}}패밀리어 눈물의 사거리가 2배로 늘어납니다."},
+	-- Blessed Penny (find replace):
+	[131] = { 17, 25, 30 },
+	-- Short Fuse (find replace):
+	[133] = { 15, 30, 50 },
+	-- Gigante Bean (append)
+	[134] = {"방귀가 적을 더 크게 밀쳐냅니다.", "방귀가 적을 더 크게 밀쳐냅니다.#{{Confusion}} {{ColorGold}}방귀가 적을 3초간 혼란시킵니다."},
+	-- Broken Padlock (find replace):
+	[136] = {"잠긴 문과 상자", "{{CR}}잠긴 문과 상자, {{ColorGold}}오락실, 도전방 문", "{{CR}}잠긴 문과 상자, {{ColorGold}}오락실, 도전방, 보스방 문"},
+	-- 'M (find replace):
+	[138] = {
+			"아이템의 충전량이 전부 소진됩니다."
+		, "10%%의 확률로 충전량을 소모하지 않습니다."
+		, "20%%의 확률로 충전량을 소모하지 않습니다."
+	},
+	-- Apple of Sodom (find replace):
+	[140] = {"빨간하트와", "하트와"},
+	-- Brain Worm (append):
+	[144] = {"25%의 확률로 적을 관통하는 공격이 나갑니다.", "50%의 확률로 적을 관통하는 공격이 나갑니다."},
+	-- Devil’s Crown (append):
+	[146] = {"{{Trinket174}} 25%의 확률로 붉은 보물방이 강화됩니다.", "{{Trinket174}} 33%의 확률로 붉은 보물방이 강화됩니다."},
+	-- Charged Penny (find replace):
+	[147] = {"한칸", "2칸", "3칸"},
+	-- Friendship Necklace (append):
+	[148] = {"캐릭터 주변을 도는 패밀리어들의 속도가 빨라집니다.", "캐릭터 주변을 도는 패밀리어들의 속도가 대폭 빨라집니다."},
+	-- Panic Button (append):
+	[149] = {"10%의 확률로 충전량을 소모하지 않습니다.", "20%의 확률로 충전량을 소모하지 않습니다."},
+	-- Blue Key (append):
+	[150] = {"파란 방 클리어 보상 2배", "파란 방 클리어 보상 3배"},
+	-- Flat File (append):
+	[151] = {"일부 보스, Grudge, Ball & Chain의 가시도 제거합니다."},
+	-- Telescope Lens (full replace):
+	[152] = {
+		"↑ {{PlanetariumChanceSmall}}천체방 확률 +{{ColorGold}}18{{CR}}%#↑ {{PlanetariumChanceSmall}}첫 천체방 확률 +15%#{{PlanetariumChanceSmall}} Womb/Corpse 스테이지에서 천체방이 등장할 수 있습니다.",
+		"↑ {{PlanetariumChanceSmall}}천체방 확률 +{{ColorGold}}33{{CR}}%#↑ {{PlanetariumChanceSmall}}첫 천체방 확률 +15%#{{PlanetariumChanceSmall}} Womb/Corpse, Sheol/Cathedral 스테이지에서 천체방이 등장할 수 있습니다.",
+	},
+	-- Holy Crown (append):
+	[155] = {
+		"Cathedral 스테이지에서의 보물방은 선택형 아이템이 하나 더 등장하며 상점은 최대 레벨로 등장합니다.",
+		"Cathedral 스테이지에서의 보물방은 선택형 아이템이 하나 더 등장하며 상점은 최대 레벨로 등장합니다.#{{ColorGold}}Cathedral 스테이지에서의 보물방, 상점의 위치를 표시합니다.",
+	},
+	-- Torn Card (find replace):
+	[157] = { 15, 10, 5 },
+	-- Gilded Key (full replace copying the entire original description, because the Golden version doesn't give a key on pickup):
+	[159] = {
+		"{{GoldenChest}} 낡은상자, 메가상자를 제외한 모든 상자가 황금상자로 교체됩니다.#{{GoldenChest}} 황금상자가 드랍하는 픽업의 양이 종류와 상관없이 최소 2개가 보장됩니다.#{{GoldenChest}} 황금상자에서 {{Rune}}룬의 등장 확률이 증가하며 {{Pill}}알약과 {{Battery}}배터리가 등장할 수 있습니다.#{{GoldenChest}} {{ColorGold}}방 클리어 시 상자 등장 확률 +10%",
+		"↑ {{Key}}열쇠 +1#{{GoldenChest}} 낡은상자, 메가상자를 제외한 모든 상자가 황금상자로 교체됩니다.#{{GoldenChest}} 황금상자가 드랍하는 픽업의 양이 종류와 상관없이 최소 2개가 보장됩니다.#{{GoldenChest}} 황금상자에서 {{Rune}}룬의 등장 확률이 증가하며 {{Pill}}알약과 {{Battery}}배터리가 등장할 수 있습니다.#{{GoldenChest}} {{ColorGold}}방 클리어 시 상자 등장 확률 +10%",
+		"{{GoldenChest}} 낡은상자, 메가상자를 제외한 모든 상자가 황금상자로 교체됩니다.#{{GoldenChest}} 황금상자가 드랍하는 픽업의 양이 종류와 상관없이 최소 2개가 보장됩니다.#{{GoldenChest}} 황금상자에서 {{Rune}}룬의 등장 확률이 증가하며 {{Pill}}알약과 {{Battery}}배터리가 등장할 수 있습니다.#{{GoldenChest}} {{ColorGold}}방 클리어 시 상자 등장 확률 +20%",
+	},
+	-- Wicked Crown (append):
+	[161] = {
+		"Sheol 스테이지에서의 보물방은 선택형 아이템이 하나 더 등장하며 상점은 최대 레벨로 등장합니다.",
+		"Sheol 스테이지에서의 보물방은 선택형 아이템이 하나 더 등장하며 상점은 최대 레벨로 등장합니다.#{{ColorGold}}Sheol 스테이지에서의 보물방, 상점의 위치를 표시합니다.",
+	},
+	-- Nuh Uh! (append):
+	[165] = {"1+1 픽업 등장 확률 +10%", "1+1 픽업 등장 확률 +20%"},
+	-- Keeper’s Bargain (full replace):
+	[171] = {
+		"{{DevilRoom}} {{ColorGold}}100{{CR}}%의 확률로 체력 거래 아이템을 동전 거래로 바꿉니다.",
+		"{{DevilRoom}} {{ColorGold}}100{{CR}}%의 확률로 체력 거래 아이템을 동전 거래로 바꿉니다.#{{ColorGold}} 악마방 상품 가격에 반값이 적용될 확률 증가",
+	},
+	-- Cursed Penny (append):
+	[172] = {"특수방으로 이동할 확률 증가"},
+	-- Your Soul (append):
+	[173] = {"10%의 확률로 장신구를 소모하지 않습니다.", "20%의 확률로 장신구를 소모하지 않습니다."},
+	-- Strange Key (full replace):
+	[175] = {
+		"{{Timer}} 30분이 지나도 ???(Blue Womb) 스테이지로 갈 수 있습니다.#{{Collectible297}}Pandora's Box 사용 시 장신구가 사라지며 랜덤 배열의 아이템 {{ColorGold}}8개{{CR}}를 생성합니다.#{{ColorGold}}??? 스테이지의 모든 장신구와 문이 열쇠를 소모하지 않습니다.",
+		"{{Timer}} 30분이 지나도 ???(Blue Womb) 스테이지로 갈 수 있습니다.#{{Collectible297}}Pandora's Box 사용 시 장신구가 사라지며 랜덤 배열의 아이템 {{ColorGold}}10개{{CR}}를 생성합니다.#{{ColorGold}}??? 스테이지의 모든 장신구와 문이 열쇠를 소모하지 않습니다.",
+	},
+	-- Temporary Tattoo (append):
+	[177] = {"도전방 클리어 시 랜덤 능력치 하나가 영구적으로 증가합니다.", "도전방 클리어 시 랜덤 능력치 2종류가 영구적으로 증가합니다."},
+	-- RC Remote (append):
+	[179] = {"패밀리어가 접촉한 적에게 틱 당 2의 피해를 줍니다. (초당 8)", "패밀리어가 접촉한 적에게 틱 당 5의 피해를 줍니다. (초당 21)"},
+	-- Expansion Pack (full replace):
+	[181] = {
+		"액티브 아이템 사용 시 충전량이 1~2인 랜덤 액티브 아이템 {{ColorGold}}2종류{{CR}}의 효과를 함께 발동합니다.#{{Blank}} (충전량이 없는 액티브 아이템의 경우 방당 1회 한정)",
+		"액티브 아이템 사용 시 충전량이 1~{{ColorGold}}3{{CR}}인 랜덤 액티브 아이템 {{ColorGold}}3종류{{CR}}의 효과를 함께 발동합니다.#{{Blank}} (충전량이 없는 액티브 아이템의 경우 방당 1회 한정)",
+	},
+	-- Beth’s Essence (append):
+	[182] = {
+		"천사방의 위습이 50%의 확률로 특수형으로 등장합니다.#{{ColorGold}}거지의 위습이 특수형으로 등장합니다.",
+		"천사방의 위습이 특수형으로 등장합니다.#{{ColorGold}}거지의 위습이 특수형으로 등장합니다.",
+	},
+	-- Adoption Papers (append):
+	[184] = {"모든 판매 중인 패밀리어가 40% 할인됩니다.", "모든 판매 중인 패밀리어가 40% 할인됩니다.#{{Card92}} {{ColorGold}}Soul of Lilith가 판매 항목에 추가될 수 있습니다."},
+	-- Sigil of Baphomet (find replace):
+	[189] = { "최대 5초", "최대 7.5초", "최대 10초",  "1초", "1.5초", "2초" },
 }
 EID:updateDescriptionsViaTable(goldenTrinketEffects, EID.descriptions[languageCode].goldenTrinketEffects)
 

--- a/descriptions/rep/ko_kr.lua
+++ b/descriptions/rep/ko_kr.lua
@@ -897,14 +897,14 @@ local repTrinkets={
 	[14] = {"14", "굳은살", "가시나 장판에 피해를 입지 않습니다.#!!! Mama Gurdy, The Pile 보스의 가시, 혹은 가시 돌에는 여전히 피해를 받습니다."}, -- Callus
 	[16] = {"16", "엄마의 발톱", "20초마다 엄마발이 랜덤 위치에 떨어집니다."}, -- Mom's Toenail
 	[15] = {"15", "행운의 돌조각", "{{Coin}} 장애물 파괴 시 33% 확률로 동전을 드랍합니다."}, -- Lucky Rock
-	[17] = {"17", "검은 립스틱", "{{BlackHeart}} 소울하트가 드랍될 때 블랙하트로 바뀔 확률 +5%p"}, -- Black Lipstick
-	[18] = {"18", "성경 책자", "{{EternalHeart}} 빨간하트가 드랍될 때 이터널하트로 바뀔 확률 +3.33%p"}, -- Bible Tract
+	[17] = {"17", "검은 립스틱", "{{BlackHeart}} 소울하트가 드랍될 때 블랙하트로 바뀔 확률 +10%p"}, -- Black Lipstick
+	[18] = {"18", "성경 책자", "{{EternalHeart}} 빨간하트가 드랍될 때 이터널하트로 바뀔 확률 +3%p"}, -- Bible Tract
 	[19] = {"19", "종이 클립", "열쇠가 필요한 모든 상자를 열쇠 소모 없이 열 수 있습니다."}, -- Paper Clip
 	[24] = {"24", "똥전", "{{Coin}} 똥 오브젝트에서 동전이 나올 확률이 20% 증가합니다.#{{Poison}} 동전 획득 시 적을 밀쳐내는 독성 방귀를 뀝니다."}, -- Butt Penny
 	[25] = {"25", "이상한 초콜릿", "!!! 30초마다 일정 확률로:#{{ArrowGrayRight}} 똥을 싸거나;#{{ArrowGrayRight}} 적과 탄환을 밀쳐내며 6의 피해를 주는 방귀를 뀝니다."}, -- Mysterious Candy
 	[26] = {"26", "꺾기벌레", "↑ {{TearsSmall}}연사 +0.4#↑ {{RangeSmall}}사거리 +1.5#눈물이 지그재그로 날아갑니다.#공격이 장애물을 관통합니다."}, -- Hook Worm
 	-- Original
-	[32] = {"32", "환각버섯", "!!! 방 입장 시 그 방에서 아래 중 랜덤 버섯 아이템 효과를 얻습니다:#{{ArrowGrayRight}} {{Collectible12}}{{Collectible71}}{{Collectible121}}{{Collectible120}}{{Collectible342}}{{Collectible398}}"}, -- Liberty Cap
+	[32] = {"32", "환각버섯", "!!! 방 입장 시 25%의 확률로 그 방에서 아래 중 랜덤 버섯 아이템 효과를 얻습니다:#{{ArrowGrayRight}} {{Collectible12}}{{Collectible71}}{{Collectible121}}{{Collectible120}}{{Collectible342}}{{Collectible398}}"}, -- Liberty Cap
 	[33] = {"33", "탯줄", "{{HalfHeart}} 방 입장 시 빨간하트가 반칸 이하일 때 {{Collectible100}}Little Steven을 소환합니다.#{{Collectible318}} 피격 시 확률적으로 그 방에서 Gemini 패밀리어를 소환합니다."}, -- Umbilical Cord
 	[39] = {"39", "암", "↑ {{TearsSmall}}연사(+상한) +1"}, -- Cancer
 	[48] = {"48", "찢어진 페이지", "{{Collectible35}} 피격 시 5%의 확률로 그 방의 적에게 80의 피해를 줍니다.#{{LuckSmall}} 행운 60 이상일 때 50% 확률#↑ {{Collectible35}} 블랙하트/The Necronomicon/The Devil의 공격력 +40"}, -- A Missing Page
@@ -914,21 +914,22 @@ local repTrinkets={
 	-- Afterbirth
 	[65] = {"65", "테이프 벌레", "↑ {{RangeSmall}}사거리 +3"}, -- Tape Worm
 	[66] = {"66", "게으른 벌레", "↓ {{ShotspeedSmall}}탄속 -0.5"}, -- Lazy Worm
-	[67] = {"67", "금이 간 주사위", "피격 시 확률적으로 {{Collectible105}}그 방의 아이템, {{Collectible166}}픽업, {{Collectible386}}오브젝트, {{Collectible406}}능력치 배율을 바꾸거나 {{Collectible285}}그 방의 적을 약화형 몬스터로 바꿉니다."}, -- Cracked Dice
-	[69] = {"69", "흐려진 즉석사진", "{{Confusion}} 때때로 그 방의 적들이 혼란에 걸립니다.#흡수하지 않은 경우 Depths 2(6 스테이지)에서 장신구를 소모하여 Home 스테이지로 진입할 수 있습니다. (해금 필요)"}, -- Faded Polaroid
+	[67] = {"67", "금이 간 주사위", "!!! 피격 시 50%의 확률로 아래 중 하나 발동:#{{ArrowGrayRight}} {{Collectible105}}그 방의 아이템 변경#{{ArrowGrayRight}} {{Collectible166}}그 방의 픽업 변경#{{ArrowGrayRight}} {{Collectible386}}그 방의 오브젝트 변경#{{ArrowGrayRight}} {{Collectible406}}캐릭터 능력치 배율 변경#{{ArrowGrayRight}} {{Collectible285}}그 방의 적을 약화형 몬스터로 변경"}, -- Cracked Dice
+	[69] = {"69", "흐려진 즉석사진", "{{Confusion}} 때때로 그 방의 적들이 혼란에 걸립니다.#(해금 필요) 흡수하지 않은 경우 Depths 2(6 스테이지)에서 장신구를 소모하여 Home 스테이지로 진입할 수 있습니다."}, -- Faded Polaroid
 	[80] = {"80", "검은 깃털", "Evil up 또는 Sin up 아이템 소지 시 개당 {{DamageSmall}}공격력이 0.5 증가합니다."}, -- Black Feather
 	[88] = {"88", "필요없어!", "모든 패시브 아이템이 등장하기 전까지 액티브 아이템이 등장하지 않습니다."}, -- NO!
+	[90] = {"90", "갈색 마개", "!!! 똥 파괴시 똥이 폭발하여 주변의 적에게 100의 피해를 줍니다."}, -- Brown Cap
 	-- Afterbirth +
 	[92] = {"92", "금이 간 왕관", "각 능력치가 캐릭터 기본 능력치보다 높을 시 각 능력치가 20% 증가합니다."}, -- Cracked Crown
 	[96] = {"96", "우주뱀 벌레", "↑ {{TearsSmall}}연사 +0.4#↑ {{RangeSmall}}사거리 +1.5#눈물이 거대한 나선을 그리며 날아갑니다.#공격이 장애물을 관통합니다.#10%의 확률로 유도 눈물을 발사합니다.#{{LuckSmall}} 행운 9 이상일 때 100% 확률"}, -- Ouroboros Worm
 	[97] = {"97", "편도선", "12~20회 피격 시 Tonsil 패밀리어를 소환합니다.#Tonsil은 캐릭터를 따라다니며 적의 탄환을 막아줍니다.#!!! 2회 소환 시 사라집니다."}, -- Tonsil
-	[98] = {"98", "콧물딱지", "10%의 확률로 접착 눈물이 나가며 접착 눈물이 적에게 붙을 시 10초동안 지속 피해를 줍니다.#접착 눈물을 발사할 때 50%의 확률로 유도 효과가 생깁니다."}, -- Nose Goblin
+	[98] = {"98", "콧물딱지", "10%의 확률로 접착 눈물이 나갑니다.#접착 눈물을 발사할 때 50%의 확률로 유도 효과가 생깁니다.#{{DamageSmall}} 접착 눈물이 적에게 붙을 시 10초동안 지속 피해를 줍니다."}, -- Nose Goblin
 	[101] = {"101", "꺼진 전구", "{{Battery}} 액티브 아이템의 충전량이 남아있지 않을때:#{{ArrowGrayRight}} {{DamageSmall}}공격력 +1.5#{{ArrowGrayRight}} {{TearsSmall}}연사 +0.5#{{ArrowGrayRight}} {{RangeSmall}}사거리 +1.5#{{ArrowGrayRight}} {{SpeedSmall}}이동속도 +0.5#{{ArrowGrayRight}} {{ShotspeedSmall}}탄속 +0.3#{{ArrowGrayRight}} {{LuckSmall}}행운 +2"}, -- Dim Bulb
 	[110] = {"110", "은화", "{{Shop}} Womb/Corpse 스테이지에서 상점이 등장합니다."},
 	[111] = {"111", "피투성이 왕관", "{{TreasureRoom}} Womb/Corpse 스테이지에서 보물방이 등장합니다."}, -- Bloody Crown
 	[119] = {"119", "줄기 세포", "{{HealingRed}} 스테이지 진입 시 최대 체력의 절반을 회복합니다.#{{HealingRed}} 체력이 최대 체력의 절반을 넘을 시 체력을 반칸 회복합니다."}, -- Stem Cell
 	[121] = {"121", "나무 십자가", "{{HolyMantle}} 스테이지 당 1번 피해를 무시하는 보호막을 생성합니다.#!!! {{Card51}}Holy Card로 생성된 보호막이 있을 경우 생성되지 않습니다."}, -- Wooden Cross
-	[128] = {"128", "손가락 뼈", "{{EmptyBoneHeart}} 피격 시 5% 확률로 뼈하트를 획득합니다."}, -- Finger Bone
+	[128] = {"128", "손가락 뼈", "{{EmptyBoneHeart}} 피격 시 4% 확률로 뼈하트를 획득합니다."}, -- Finger Bone
 	-- Repentance
 	[129] = {"129", "눈깔사탕", "{{Collectible150}} 10%의 확률로 공격력 x3.2의 공격이 나갑니다.#{{LuckSmall}} 행운 9 이상일 때 100% 확률"}, -- Jawbreaker
 	[130] = {"130", "씹던 펜", "{{Slow}} 10%의 확률로 적을 둔화시키는 공격이 나갑니다.#{{LuckSmall}} 행운 18 이상일 때 100% 확률"}, -- Chewed Pen
@@ -947,15 +948,15 @@ local repTrinkets={
 	[143] = {"143", "오래된 축전기", "!!! 방을 클리어해도 액티브 아이템이 충전되지 않습니다.#{{Battery}} 방 클리어 시 20%의 확률로 배터리 픽업을 드랍합니다.#{{LuckSmall}} 행운 5 이상일 때 33% 확률"}, -- Old Capacitor
 	[144] = {"144", "두뇌 벌레", "공격이 적이 있는 방향을 향해 직선으로 날아갑니다."}, -- Brain Worm
 	[145] = {"145", "올백", "↑ {{LuckSmall}}행운 +10#!!! 패널티 피격 시 사라집니다."}, -- Perfection
-	[146] = {"146", "악마의 왕관", "{{TreasureRoom}}보물방 아이템이 체력 거래가 필요한 {{DevilRoom}}악마방 아이템으로 대체됩니다."}, -- Devil's Crown
+	[146] = {"146", "악마의 왕관", "{{TreasureRoom}} 보물방이 체력 거래가 필요한 {{DevilRoom}}악마방 아이템이 나오는 붉은 보물방으로 대체됩니다."}, -- Devil's Crown
 	[147] = {"147", "충전된 동전", "{{Battery}} 동전 획득 시 17%의 확률로 액티브 아이템 충전량을 한칸 충전합니다.#동전 가치가 높을수록 확률 증가"}, -- Charged Penny
 	[148] = {"148", "우정의 목걸이", "패밀리어가 캐릭터의 주위를 돕니다."}, -- Friendship Necklace
 	[149] = {"149", "패닉 버튼", "액티브 아이템 충전량이 최대치일 때 피격 직전에 액티브 아이템을 사용합니다."}, -- Panic Button
-	[150] = {"150", "푸른 열쇠", "열쇠로 잠긴 방에 들어갈 때 열쇠를 소모하지 않으며 특수한 적이 있는 방 클리어 후 입장할 수 있습니다."}, -- Blue Key
+	[150] = {"150", "푸른 열쇠", "열쇠로 잠긴 방에 들어갈 때 열쇠를 소모하지 않으며 특수한 적이 있는 파란 방 클리어 후 입장할 수 있습니다."}, -- Blue Key
 	[151] = {"151", "쇠줄", "모든 바닥, 상자, 문, 바위의 가시를 제거합니다.#!!! 희생방의 가시도 제거합니다."}, -- Flat File
 	[152] = {"152", "망원경 렌즈", "↑ {{PlanetariumChanceSmall}}천체방 확률 +9%#↑ {{PlanetariumChanceSmall}}첫 천체방 확률 +15%#{{PlanetariumChanceSmall}} Womb/Corpse 스테이지에서 천체방이 등장할 수 있습니다."}, -- Telescope Lens
-	[153] = {"153", "엄마의 머리뭉치", "방 입장 시 확률적으로 그 방에서 랜덤 엄마 아이템 효과를 얻습니다."}, -- Mom's Lock
-	[154] = {"154", "주사위 가방", "방 입장 시 확률적으로 그 방에서 랜덤 일회용 주사위 아이템 픽업을 얻습니다."}, -- Dice Bag
+	[153] = {"153", "엄마의 머리뭉치", "방 입장 시 25%의 확률로 그 방에서 랜덤 엄마 아이템 효과를 얻습니다."}, -- Mom's Lock
+	[154] = {"154", "주사위 가방", "방 입장 시 50%의 확률로 그 방에서 랜덤 일회용 주사위 아이템 픽업을 얻습니다."}, -- Dice Bag
 	[155] = {"155", "신성한 왕관", "Cathedral 스테이지에서 {{TreasureRoom}}보물방과 {{Shop}}상점이 등장합니다."}, -- Holy Crown
 	[156] = {"156", "어머니의 키스", "{{Heart}} 소지중일 때 최대 체력 +1"}, -- Mother's Kiss
 	[157] = {"157", "찢어진 카드", "!!! 눈물을 15번 발사할 때 마다:#{{ArrowGrayRight}} {{Collectible5}}{{Collectible149}}캐릭터에게 되돌아오는 폭발하는 독성 눈물을 발사합니다."}, -- Torn Card
@@ -972,7 +973,7 @@ local repTrinkets={
 	[168] = {"168", "텅 빈 심장", "{{EmptyBoneHeart}} 스테이지 진입 시 뼈하트 +1"}, -- Hollow Heart
 	[169] = {"169", "아이의 그림", "소지중일 때 Guppy 세트에 포함됩니다."}, -- Kid's Drawing
 	[170] = {"170", "수정 열쇠", "{{RedRoom}} 방 클리어 시 33%의 확률로 가까운 벽에 빨간방으로 가는 문이 생성됩니다.#빨간방은 일반방 또는 특수방의 구조로 생성될 수 있습니다.#빨간방 안에서는 또다른 빨간방 생성 확률이 감소합니다."}, -- Crystal Key
-	[171] = {"171", "키퍼의 흥정", "50%의 확률로 체력 거래 아이템을 동전 거래로 바꿉니다."}, -- Keeper's Bargain
+	[171] = {"171", "키퍼의 흥정", "{{DevilRoom}} 50%의 확률로 체력 거래 아이템을 동전 거래로 바꿉니다."}, -- Keeper's Bargain
 	[172] = {"172", "저주받은 동전", "동전 획득 시 랜덤 방으로 순간이동합니다."}, -- Cursed Penny
 	[173] = {"173", "네 영혼", "!!! 일회용#체력 거래 시 체력 대신 장신구를 소모합니다.#!!! {{DevilRoom}}악마방/{{Collectible292}}Satanic Bible 거래 시 여전히 악마 거래로 취급됩니다."}, -- Your Soul
 	[174] = {"174", "숫자 자석", "↑ {{DevilChanceSmall}}악마방 확률 +10%#{{DevilRoom}} 악마방에서 Krampus 보스가 등장하지 않습니다.#{{DevilRoom}} 악마방 구조가 특수하게 변경되며 악마방에서 적들과 {{BlackHeart}}블랙하트의 등장 확률 및 빈도가 높아집니다."}, -- Number Magnet
@@ -981,7 +982,7 @@ local repTrinkets={
 	[177] = {"177", "스티커 문신", "{{ChallengeRoom}} 도전방 클리어 시 상자를 드랍합니다.#{{ChallengeRoom}} 보스 도전방 클리어 시 아이템을 생성합니다."}, -- Temporary Tattoo
 	[178] = {"178", "삼킨 M80", "피격 시 50% 확률로 캐릭터의 위치에 공격력 185의 폭발을 일으킵니다."}, -- Swallowed M80
 	[179] = {"179", "RC 리모콘", "패밀리어가 캐릭터가 움직이는 방향으로 이동합니다."}, -- RC Remote
-	[180] = {"180", "되찾은 영혼", "캐릭터와 같이 이동하며 공격방향으로 캐릭터의 공격과 같은 공격을 발사합니다.#적에게 맞을 시 사라지고 다음 스테이지에서 재소환됩니다."}, -- Found Soul
+	[180] = {"180", "되찾은 영혼", "캐릭터와 같이 이동하며 공격방향으로 캐릭터의 공격력 x0.5의 공격을 발사합니다.#적에게 맞을 시 사라지고 다음 스테이지에서 재소환됩니다."}, -- Found Soul
 	[181] = {"181", "확장팩", "액티브 아이템 사용 시 충전량이 1~2인 랜덤 액티브 아이템의 효과를 함께 발동합니다.#{{Blank}} (충전량이 없는 액티브 아이템의 경우 방당 1회 한정)"}, -- Expansion Pack
 	[182] = {"182", "베다니의 정수", "{{Collectible584}} {{AngelRoom}}천사방 입장 시 위습을 5마리 소환합니다.#{{Collectible584}} 거지에게 기부 시 25%의 확률로 위습을 소환합니다."}, -- Beth's Essence
 	[183] = {"183", "쌍둥이", "방 입장 시 50% 확률로 그 방에서 랜덤 패밀리어 중 하나를 복사합니다.#복사할 수 있는 패밀리어가 없다면 {{Collectible8}}Brother Bobby 혹은 {{Collectible67}}Sister Maggy를 대신 소환합니다."}, -- The Twins
@@ -1015,6 +1016,8 @@ EID.descriptions[languageCode].goldenTrinketEffects = {
 	[20] = {"하나", "2개", "3개"},
 	-- Golden Mysterious Candy makes Golden Poop
 	[25] = { "똥", "황금 똥" },
+	-- Fish Head
+	[29] = {"하나", "2마리", "3마리"},
 	-- Isaac's Fork (find+replace): find Phrase #1 in the localized description, change it to Phrase #2 or 3 for doubled/tripled
 	[46] = { "반칸", "한칸", "한칸 반" },
 	-- Tick (replace): A full replacement for Golden / Mom's Box / Both, as the Golden version can be removed and only one effect is tripled
@@ -1058,6 +1061,7 @@ EID.descriptions[languageCode].goldenTrinketEffects = {
 EID.descriptions[languageCode].goldenTrinketData = {
 	[8] = {append = true},
 	[20] = {findReplace = true},
+	[29] = {findReplace = true},
 	[70] = {findReplace = true},
 	[72] = {findReplace = true},
 	[85] = {fullReplace = true},


### PR DESCRIPTION
updated golden trinkets descriptions for 1.9.7.13
- follows most of en_us entries

fix, update descriptions for
- Swallowed Penny
- Fish Head
- Meconium
- Super Ball
- Walnut
- Locust of War
- Locust of Pestilence
- Locust of Famine
- Locust of Death
- Locust of Conquest
- Bat Wing
- Rotten Penny
- Black Lipstick
- Bible Tract
- Liberty Cap
- Cracked Dice
- Faded Polaroid
- Nose Goblin
- Finger Bone
- Devil's Crown
- Blue Key
- Mom's Lock
- Dice Bag
- Keeper's Bargain
- Found Soul

updated descriptions for
- Doctor's Remote
- Tough Love
- Linger Bean
- Mom's Razor