### PR TITLE
Issue regarding game crashes after executing "rewind" command and potential fix for EID player entity references

### DIFF
--- a/features/eid_api.lua
+++ b/features/eid_api.lua
@@ -2939,7 +2939,7 @@ function EID:UpdateAllPlayerPassiveItems()
 	-- check if id is smaller max id, because numbers bigger a certain value can crash the game when calling HasCollectible()
 	local maxCollID = EID:GetMaxCollectibleID()
 	for i = 1, #EID.coopAllPlayers do
-		local player = EID.coopAllPlayers[i]
+		local player = Isaac.GetPlayer(i-1)
 		if player == nil then
 			return listUpdatedForPlayers -- dont evaluate when bad data is present
 		end


### PR DESCRIPTION
Hello,

I am currently developing a mod that implements a single-button rewind feature by calling `Isaac.ExecuteCommand("rewind")` within the `MC_POST_RENDER` callback.

However, I have encountered intermittent game crashes immediately following the rewind execution. Based on the log output, the crash occurs within the **External Item Descriptions (EID)** mod:

```text
[INFO] - [C](-1): HasCollectible
[INFO] - ...xternal item descriptions_836319872/features/eid_api.lua(2909): UpdateAllPlayerPassiveItems
[INFO] - ...birth/mods/external item descriptions_836319872/main.lua(1141): Function
[INFO] - resources/scripts/main.lua(73): ?
[INFO] - Caught exception, writing minidump...

```

Upon further investigation, it appears that the player objects stored in the `EID.coopAllPlayers[i]` table become invalidated or "stale" after the rewind command is executed. Consequently, when the mod attempts to call `player:HasCollectible` on these invalid references, the game crashes.

I am considering refactoring this logic to use `Isaac.GetPlayer(i - 1)` instead of the cached table to ensure the mod always references the most up-to-date player entities. Since `EID:getPlayerID` already utilizes `Isaac.GetPlayer`, would this be a recommended approach to resolve the reference instability caused by rewinding?

I look forward to your insights on this.
