### PR TITLE
ko_kr : module desc update

### DIFF
--- a/descriptions/modular/ko_kr.lua
+++ b/descriptions/modular/ko_kr.lua
@@ -38,7 +38,7 @@ EID.descriptions[languageCode].ModularDescriptions = {
     RandomStatDown = "↓ 무작위 능력치 {value}개 감소",
 
     -- Health related
-    RedHeart = "빨간하트 {value}",
+    RedHeart = "최대 체력 {value}",
     SoulHeart = "소울하트 {value}",
     BlackHeart = "블랙하트 {value}",
     BoneHeart = "뼈하트 {value}",


### PR DESCRIPTION
the translation for `Health` was originally matched as `최대 체력`, but the module description uses `빨간하트`.

this could give the impression that health items like Breakfast describe effects as `Heal 1 red heart, Heal 1 red heart` instead of `Health +1, Heal 1 red heart`.

therefore, i am reverting to the original translation.