### PR TITLE
Prevent EID:getObjectName() returning Empty name from default lang

### DIFF
--- a/features/eid_api.lua
+++ b/features/eid_api.lua
@@ -918,7 +918,7 @@ function EID:getObjectName(Type, Variant, SubType)
 	local translatedName = EID.ItemNames[EID:getLanguage()][fallbackName]
 	local itemNameTableEntry = translatedName ~= "" and translatedName or EID.ItemNames[EID.DefaultLanguageCode][fallbackName]
 	-- return itemName table entry if found and not pills/horsepills
-	-- don't return itemName table entry if no names are found since 'EID.ItemNames[EID.DefaultLanguageCode][fallbackName]' can also be empty
+	-- 'EID.ItemNames[EID.DefaultLanguageCode][fallbackName]' can also be empty check if it is empty again, to check ItemConfig stuff propery
 	if itemNameTableEntry and itemNameTableEntry ~= "" and tableName ~= "pills" and tableName ~= "horsepills" then return itemNameTableEntry end
 
 	local tableEntry = EID:getDescriptionData(Type, Variant, SubType)


### PR DESCRIPTION

<img width="1125" height="632" alt="스크린샷 2026-01-26 103414" src="https://github.com/user-attachments/assets/e0d14dd3-68b7-4769-89b9-8f2fb677c620" />

- Check empty string for both current + english from `EID.ItemNames` table, so it could check ItemConfig names if names from table is empty.
- This should fix english name showing as blank text when `Name Language` option is set as `Current + English`
- This is rare case since most mods add english descriptions